### PR TITLE
Ignore unhyphenated uuids. Refactor tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -20,6 +20,7 @@ use crate::contract_info::{
 use crate::error::ContractError;
 use crate::error::ContractError::InvalidPricePrecisionSizePair;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, Validate};
+use crate::util::to_hyphenated_uuid_str;
 use crate::version_info::{
     get_version_info, migrate_version_info, set_version_info, VersionInfoV1, CRATE_NAME,
     PACKAGE_VERSION,
@@ -152,7 +153,9 @@ pub fn execute(
     msg.validate()?;
 
     match msg {
-        ExecuteMsg::ApproveAsk { id, base, size } => approve_ask(deps, env, info, id, base, size),
+        ExecuteMsg::ApproveAsk { id, base, size } => {
+            approve_ask(deps, env, info, to_hyphenated_uuid_str(id)?, base, size)
+        }
         ExecuteMsg::CreateAsk {
             id,
             base,
@@ -166,7 +169,7 @@ pub fn execute(
             AskOrderV1 {
                 base,
                 class: AskOrderClass::Basic,
-                id,
+                id: to_hyphenated_uuid_str(id)?,
                 owner: info.sender.to_owned(),
                 quote,
                 price,
@@ -192,7 +195,7 @@ pub fn execute(
                 },
                 events: vec![],
                 fee,
-                id,
+                id: to_hyphenated_uuid_str(id)?,
                 owner: info.sender.to_owned(),
                 price,
                 quote: Coin {
@@ -201,28 +204,61 @@ pub fn execute(
                 },
             },
         ),
-        ExecuteMsg::CancelAsk { id } => cancel_ask(deps, env, info, id),
-        ExecuteMsg::CancelBid { id } => {
-            reverse_bid(deps, env, info, id, String::from("cancel_bid"), None)
-        }
+        ExecuteMsg::CancelAsk { id } => cancel_ask(deps, env, info, to_hyphenated_uuid_str(id)?),
+        ExecuteMsg::CancelBid { id } => reverse_bid(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(id)?,
+            String::from("cancel_bid"),
+            None,
+        ),
         ExecuteMsg::ExecuteMatch {
             ask_id,
             bid_id,
             price,
             size,
-        } => execute_match(deps, env, info, ask_id, bid_id, price, size),
-        ExecuteMsg::ExpireAsk { id } => {
-            reverse_ask(deps, env, info, id, String::from("expire_ask"), None)
-        }
-        ExecuteMsg::ExpireBid { id } => {
-            reverse_bid(deps, env, info, id, String::from("expire_bid"), None)
-        }
-        ExecuteMsg::RejectAsk { id, size } => {
-            reverse_ask(deps, env, info, id, String::from("reject_ask"), size)
-        }
-        ExecuteMsg::RejectBid { id, size } => {
-            reverse_bid(deps, env, info, id, String::from("reject_bid"), size)
-        }
+        } => execute_match(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(ask_id)?,
+            to_hyphenated_uuid_str(bid_id)?,
+            price,
+            size,
+        ),
+        ExecuteMsg::ExpireAsk { id } => reverse_ask(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(id)?,
+            String::from("expire_ask"),
+            None,
+        ),
+        ExecuteMsg::ExpireBid { id } => reverse_bid(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(id)?,
+            String::from("expire_bid"),
+            None,
+        ),
+        ExecuteMsg::RejectAsk { id, size } => reverse_ask(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(id)?,
+            String::from("reject_ask"),
+            size,
+        ),
+        ExecuteMsg::RejectBid { id, size } => reverse_bid(
+            deps,
+            env,
+            info,
+            to_hyphenated_uuid_str(id)?,
+            String::from("reject_bid"),
+            size,
+        ),
         ExecuteMsg::ModifyContract {
             approvers,
             executors,
@@ -1700,11 +1736,11 @@ pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult
     match msg {
         QueryMsg::GetAsk { id } => {
             let ask_storage_read = get_ask_storage_read(deps.storage);
-            return to_binary(&ask_storage_read.load(id.as_bytes())?);
+            return to_binary(&ask_storage_read.load(to_hyphenated_uuid_str(id)?.as_bytes())?);
         }
         QueryMsg::GetBid { id } => {
             let bid_storage_read = get_bid_storage_read(deps.storage);
-            return to_binary(&bid_storage_read.load(id.as_bytes())?);
+            return to_binary(&bid_storage_read.load(to_hyphenated_uuid_str(id)?.as_bytes())?);
         }
         QueryMsg::GetContractInfo {} => to_binary(&get_contract_info(deps.storage)?),
         QueryMsg::GetVersionInfo {} => to_binary(&get_version_info(deps.storage)?),

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use cosmwasm_std::StdError;
 use semver::Error as SemverError;
 use serde_json::Error;
 use thiserror::Error;
+use uuid::Error as UuidError;
 
 #[derive(Error, Debug)]
 pub enum ContractError {
@@ -76,6 +77,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     SemverError(#[from] SemverError),
+
+    #[error("{0}")]
+    UuidError(#[from] UuidError),
 
     #[error("Total (price * size) exceeds max allowed")]
     TotalOverflow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,6 @@ pub mod contract;
 pub mod contract_info;
 pub mod error;
 pub mod msg;
+pub mod tests;
+pub mod util;
 pub mod version_info;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,8 +1,8 @@
 use crate::error::ContractError;
+use crate::util::is_hyphenated_uuid_str;
 use cosmwasm_std::{Coin, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -169,7 +169,7 @@ impl Validate for ExecuteMsg {
 
         match self {
             ExecuteMsg::ApproveAsk { id, base, size } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
                 if base.is_empty() {
@@ -186,7 +186,7 @@ impl Validate for ExecuteMsg {
                 price,
                 size,
             } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
                 if base.is_empty() {
@@ -211,7 +211,7 @@ impl Validate for ExecuteMsg {
                 quote_size,
                 size,
             } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
                 if base.is_empty() {
@@ -236,12 +236,12 @@ impl Validate for ExecuteMsg {
                 }
             }
             ExecuteMsg::CancelAsk { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }
             ExecuteMsg::CancelBid { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }
@@ -251,10 +251,10 @@ impl Validate for ExecuteMsg {
                 price,
                 size,
             } => {
-                if Uuid::parse_str(ask_id).is_err() {
+                if !is_hyphenated_uuid_str(ask_id) {
                     invalid_fields.push("ask_id");
                 }
-                if Uuid::parse_str(bid_id).is_err() {
+                if !is_hyphenated_uuid_str(bid_id) {
                     invalid_fields.push("bid_id");
                 }
                 if price.is_empty() {
@@ -265,17 +265,17 @@ impl Validate for ExecuteMsg {
                 }
             }
             ExecuteMsg::ExpireAsk { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }
             ExecuteMsg::ExpireBid { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }
             ExecuteMsg::RejectAsk { id, size } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
                 if let Some(size) = size {
@@ -285,7 +285,7 @@ impl Validate for ExecuteMsg {
                 }
             }
             ExecuteMsg::RejectBid { id, size } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
                 if let Some(size) = size {
@@ -378,12 +378,12 @@ impl Validate for QueryMsg {
 
         match self {
             QueryMsg::GetAsk { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }
             QueryMsg::GetBid { id } => {
-                if Uuid::parse_str(id).is_err() {
+                if !is_hyphenated_uuid_str(id) {
                     invalid_fields.push("id");
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,4 @@
+pub mod execute;
+pub mod query;
+pub mod test_constants;
+pub mod test_utils;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 pub mod execute;
 pub mod query;
 pub mod test_constants;
+pub mod test_setup_utils;
 pub mod test_utils;

--- a/src/tests/execute.rs
+++ b/src/tests/execute.rs
@@ -1,0 +1,10 @@
+mod approve_ask_tests;
+mod cancel_ask_tests;
+mod cancel_bid_tests;
+mod create_ask_tests;
+mod create_bid_tests;
+mod execute_match_tests;
+mod expire_ask_tests;
+mod expire_bid_tests;
+mod reject_ask_tests;
+mod reject_bid_tests;

--- a/src/tests/execute/approve_ask_tests.rs
+++ b/src/tests/execute/approve_ask_tests.rs
@@ -1,0 +1,124 @@
+#[cfg(test)]
+mod approve_ask_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coin, Addr, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn approve_ask_valid_unhyphenated_id() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+        let mock_env = mock_env();
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "con_base_1".into(),
+                class: AskOrderClass::Convertible {
+                    status: AskOrderStatus::PendingIssuerApproval,
+                },
+                id: HYPHENATED_ASK_ID.into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        let approve_ask_response = execute(
+            deps.as_mut(),
+            mock_env,
+            mock_info("approver_1", &[coin(100, "base_denom")]),
+            ExecuteMsg::ApproveAsk {
+                id: UNHYPHENATED_ASK_ID.into(),
+                base: "base_denom".to_string(),
+                size: Uint128::new(100),
+            },
+        );
+
+        // validate ask response
+        match approve_ask_response {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(approve_ask_response) => {
+                assert_eq!(approve_ask_response.attributes.len(), 6);
+                assert_eq!(
+                    approve_ask_response.attributes[0],
+                    attr("action", "approve_ask")
+                );
+                assert_eq!(
+                    approve_ask_response.attributes[1],
+                    attr("id", HYPHENATED_ASK_ID)
+                );
+                assert_eq!(
+                    approve_ask_response.attributes[2],
+                    attr(
+                        "class",
+                        serde_json::to_string(&AskOrderClass::Convertible {
+                            status: AskOrderStatus::Ready {
+                                approver: Addr::unchecked("approver_1"),
+                                converted_base: coin(100, "base_denom")
+                            },
+                        })
+                        .unwrap()
+                    )
+                );
+                assert_eq!(approve_ask_response.attributes[3], attr("quote", "quote_1"));
+                assert_eq!(approve_ask_response.attributes[4], attr("price", "2"));
+                assert_eq!(approve_ask_response.attributes[5], attr("size", "100"));
+                assert_eq!(approve_ask_response.messages.len(), 0);
+            }
+        }
+
+        // verify ask order update
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        match ask_storage.load(HYPHENATED_ASK_ID.as_bytes()) {
+            Ok(stored_order) => {
+                assert_eq!(
+                    stored_order,
+                    AskOrderV1 {
+                        base: "con_base_1".into(),
+                        class: AskOrderClass::Convertible {
+                            status: AskOrderStatus::Ready {
+                                approver: Addr::unchecked("approver_1"),
+                                converted_base: coin(100, "base_denom"),
+                            },
+                        },
+                        id: HYPHENATED_ASK_ID.into(),
+                        owner: Addr::unchecked("asker"),
+                        price: "2".into(),
+                        quote: "quote_1".into(),
+                        size: Uint128::new(100),
+                    }
+                )
+            }
+            _ => {
+                panic!("ask order was not found in storage")
+            }
+        }
+    }
+}

--- a/src/tests/execute/approve_ask_tests.rs
+++ b/src/tests/execute/approve_ask_tests.rs
@@ -1,58 +1,22 @@
 #[cfg(test)]
 mod approve_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coin, Addr, Uint128};
+    use cosmwasm_std::{coin, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn approve_ask_valid_unhyphenated_id() {
-        // setup
+    fn approve_ask_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        let mock_env = mock_env();
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        store_test_ask(
-            &mut deps.storage,
-            &AskOrderV1 {
-                base: "con_base_1".into(),
-                class: AskOrderClass::Convertible {
-                    status: AskOrderStatus::PendingIssuerApproval,
-                },
-                id: HYPHENATED_ASK_ID.into(),
-                owner: Addr::unchecked("asker"),
-                price: "2".into(),
-                quote: "quote_1".into(),
-                size: Uint128::new(100),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         let approve_ask_response = execute(
             deps.as_mut(),
-            mock_env,
+            mock_env(),
             mock_info("approver_1", &[coin(100, "base_denom")]),
             ExecuteMsg::ApproveAsk {
                 id: UNHYPHENATED_ASK_ID.into(),
@@ -61,64 +25,7 @@ mod approve_ask_tests {
             },
         );
 
-        // validate ask response
-        match approve_ask_response {
-            Err(error) => panic!("unexpected error: {:?}", error),
-            Ok(approve_ask_response) => {
-                assert_eq!(approve_ask_response.attributes.len(), 6);
-                assert_eq!(
-                    approve_ask_response.attributes[0],
-                    attr("action", "approve_ask")
-                );
-                assert_eq!(
-                    approve_ask_response.attributes[1],
-                    attr("id", HYPHENATED_ASK_ID)
-                );
-                assert_eq!(
-                    approve_ask_response.attributes[2],
-                    attr(
-                        "class",
-                        serde_json::to_string(&AskOrderClass::Convertible {
-                            status: AskOrderStatus::Ready {
-                                approver: Addr::unchecked("approver_1"),
-                                converted_base: coin(100, "base_denom")
-                            },
-                        })
-                        .unwrap()
-                    )
-                );
-                assert_eq!(approve_ask_response.attributes[3], attr("quote", "quote_1"));
-                assert_eq!(approve_ask_response.attributes[4], attr("price", "2"));
-                assert_eq!(approve_ask_response.attributes[5], attr("size", "100"));
-                assert_eq!(approve_ask_response.messages.len(), 0);
-            }
-        }
-
-        // verify ask order update
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load(HYPHENATED_ASK_ID.as_bytes()) {
-            Ok(stored_order) => {
-                assert_eq!(
-                    stored_order,
-                    AskOrderV1 {
-                        base: "con_base_1".into(),
-                        class: AskOrderClass::Convertible {
-                            status: AskOrderStatus::Ready {
-                                approver: Addr::unchecked("approver_1"),
-                                converted_base: coin(100, "base_denom"),
-                            },
-                        },
-                        id: HYPHENATED_ASK_ID.into(),
-                        owner: Addr::unchecked("asker"),
-                        price: "2".into(),
-                        quote: "quote_1".into(),
-                        size: Uint128::new(100),
-                    }
-                )
-            }
-            _ => {
-                panic!("ask order was not found in storage")
-            }
-        }
+        // verify execute approve ask response
+        validate_execute_invalid_id_field(approve_ask_response)
     }
 }

--- a/src/tests/execute/cancel_ask_tests.rs
+++ b/src/tests/execute/cancel_ask_tests.rs
@@ -1,0 +1,89 @@
+#[cfg(test)]
+mod cancel_ask_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn cancel_ask_valid_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "base_1".into(),
+                class: AskOrderClass::Basic,
+                id: HYPHENATED_ASK_ID.into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        // cancel ask order
+        let asker_info = mock_info("asker", &[]);
+
+        let cancel_ask_msg = ExecuteMsg::CancelAsk {
+            id: UNHYPHENATED_ASK_ID.to_string(),
+        };
+        let cancel_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            cancel_ask_msg,
+        );
+
+        match cancel_ask_response {
+            Ok(cancel_ask_response) => {
+                assert_eq!(cancel_ask_response.attributes.len(), 2);
+                assert_eq!(
+                    cancel_ask_response.attributes[0],
+                    attr("action", "cancel_ask")
+                );
+                assert_eq!(
+                    cancel_ask_response.attributes[1],
+                    attr("id", HYPHENATED_ASK_ID)
+                );
+                assert_eq!(cancel_ask_response.messages.len(), 1);
+                assert_eq!(
+                    cancel_ask_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: asker_info.sender.to_string(),
+                        amount: coins(100, "base_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify ask order removed from storage
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/cancel_ask_tests.rs
+++ b/src/tests/execute/cancel_ask_tests.rs
@@ -1,50 +1,17 @@
 #[cfg(test)]
 mod cancel_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn cancel_ask_valid_unhyphenated_id() {
+    fn cancel_ask_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        store_test_ask(
-            &mut deps.storage,
-            &AskOrderV1 {
-                base: "base_1".into(),
-                class: AskOrderClass::Basic,
-                id: HYPHENATED_ASK_ID.into(),
-                owner: Addr::unchecked("asker"),
-                price: "2".into(),
-                quote: "quote_1".into(),
-                size: Uint128::new(100),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // cancel ask order
         let asker_info = mock_info("asker", &[]);
@@ -59,31 +26,7 @@ mod cancel_ask_tests {
             cancel_ask_msg,
         );
 
-        match cancel_ask_response {
-            Ok(cancel_ask_response) => {
-                assert_eq!(cancel_ask_response.attributes.len(), 2);
-                assert_eq!(
-                    cancel_ask_response.attributes[0],
-                    attr("action", "cancel_ask")
-                );
-                assert_eq!(
-                    cancel_ask_response.attributes[1],
-                    attr("id", HYPHENATED_ASK_ID)
-                );
-                assert_eq!(cancel_ask_response.messages.len(), 1);
-                assert_eq!(
-                    cancel_ask_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: asker_info.sender.to_string(),
-                        amount: coins(100, "base_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        // verify execute cancel ask response
+        validate_execute_invalid_id_field(cancel_ask_response)
     }
 }

--- a/src/tests/execute/cancel_bid_tests.rs
+++ b/src/tests/execute/cancel_bid_tests.rs
@@ -1,56 +1,18 @@
 #[cfg(test)]
 mod cancel_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use crate::tests::test_constants::UNHYPHENATED_BID_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use cosmwasm_std::{Addr, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn cancel_bid_valid_unhyphenated_id() {
+    fn cancel_bid_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // create bid data
-        store_test_bid(
-            &mut deps.storage,
-            &BidOrderV2 {
-                base: Coin {
-                    amount: Uint128::new(100),
-                    denom: "base_1".into(),
-                },
-                events: vec![],
-                fee: None,
-                id: HYPHENATED_BID_ID.into(),
-                owner: Addr::unchecked("bidder"),
-                price: "2".into(),
-                quote: Coin {
-                    amount: Uint128::new(200),
-                    denom: "quote_1".into(),
-                },
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // cancel bid order
         let bidder_info = mock_info("bidder", &[]);
@@ -66,39 +28,6 @@ mod cancel_bid_tests {
             cancel_bid_msg,
         );
 
-        match cancel_bid_response {
-            Ok(cancel_bid_response) => {
-                assert_eq!(cancel_bid_response.attributes.len(), 4);
-                assert_eq!(
-                    cancel_bid_response.attributes[0],
-                    attr("action", "cancel_bid")
-                );
-                assert_eq!(
-                    cancel_bid_response.attributes[1],
-                    attr("id", HYPHENATED_BID_ID)
-                );
-                assert_eq!(
-                    cancel_bid_response.attributes[2],
-                    attr("reverse_size", "100")
-                );
-                assert_eq!(
-                    cancel_bid_response.attributes[3],
-                    attr("order_open", "false")
-                );
-                assert_eq!(cancel_bid_response.messages.len(), 1);
-                assert_eq!(
-                    cancel_bid_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: bidder_info.sender.to_string(),
-                        amount: coins(200, "quote_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        validate_execute_invalid_id_field(cancel_bid_response)
     }
 }

--- a/src/tests/execute/cancel_bid_tests.rs
+++ b/src/tests/execute/cancel_bid_tests.rs
@@ -1,0 +1,104 @@
+#[cfg(test)]
+mod cancel_bid_tests {
+    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn cancel_bid_valid_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // create bid data
+        store_test_bid(
+            &mut deps.storage,
+            &BidOrderV2 {
+                base: Coin {
+                    amount: Uint128::new(100),
+                    denom: "base_1".into(),
+                },
+                events: vec![],
+                fee: None,
+                id: HYPHENATED_BID_ID.into(),
+                owner: Addr::unchecked("bidder"),
+                price: "2".into(),
+                quote: Coin {
+                    amount: Uint128::new(200),
+                    denom: "quote_1".into(),
+                },
+            },
+        );
+
+        // cancel bid order
+        let bidder_info = mock_info("bidder", &[]);
+
+        let cancel_bid_msg = ExecuteMsg::CancelBid {
+            id: UNHYPHENATED_BID_ID.to_string(),
+        };
+
+        let cancel_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            bidder_info.clone(),
+            cancel_bid_msg,
+        );
+
+        match cancel_bid_response {
+            Ok(cancel_bid_response) => {
+                assert_eq!(cancel_bid_response.attributes.len(), 4);
+                assert_eq!(
+                    cancel_bid_response.attributes[0],
+                    attr("action", "cancel_bid")
+                );
+                assert_eq!(
+                    cancel_bid_response.attributes[1],
+                    attr("id", HYPHENATED_BID_ID)
+                );
+                assert_eq!(
+                    cancel_bid_response.attributes[2],
+                    attr("reverse_size", "100")
+                );
+                assert_eq!(
+                    cancel_bid_response.attributes[3],
+                    attr("order_open", "false")
+                );
+                assert_eq!(cancel_bid_response.messages.len(), 1);
+                assert_eq!(
+                    cancel_bid_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: bidder_info.sender.to_string(),
+                        amount: coins(200, "quote_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify bid order removed from storage
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/create_ask_tests.rs
+++ b/src/tests/execute/create_ask_tests.rs
@@ -1,0 +1,119 @@
+#[cfg(test)]
+mod create_ask_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::setup_test_base;
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn create_ask_valid_data_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_1".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        deps.querier.with_attributes(
+            "asker",
+            &[
+                ("ask_tag_1", "ask_tag_1_value", "String"),
+                ("ask_tag_2", "ask_tag_2_value", "String"),
+            ],
+        );
+
+        // create ask data
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            id: UNHYPHENATED_ASK_ID.into(),
+            price: "2.5".into(),
+            quote: "quote_1".into(),
+            base: "base_1".to_string(),
+            size: Uint128::new(200),
+        };
+
+        let asker_info = mock_info("asker", &coins(200, "base_1"));
+
+        // execute create ask
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info,
+            create_ask_msg.clone(),
+        );
+
+        // verify create ask response
+        match create_ask_response {
+            Ok(response) => {
+                assert_eq!(response.attributes.len(), 8);
+                assert_eq!(response.attributes[0], attr("action", "create_ask"));
+                assert_eq!(response.attributes[1], attr("id", HYPHENATED_ASK_ID));
+                assert_eq!(
+                    response.attributes[2],
+                    attr(
+                        "class",
+                        serde_json::to_string(&AskOrderClass::Basic {}).unwrap()
+                    )
+                );
+                assert_eq!(response.attributes[3], attr("target_base", "base_1"));
+                assert_eq!(response.attributes[4], attr("base", "base_1"));
+                assert_eq!(response.attributes[5], attr("quote", "quote_1"));
+                assert_eq!(response.attributes[6], attr("price", "2.5"));
+                assert_eq!(response.attributes[7], attr("size", "200"));
+            }
+            Err(error) => {
+                panic!("failed to create ask: {:?}", error)
+            }
+        }
+
+        // verify ask order stored
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        if let ExecuteMsg::CreateAsk {
+            id,
+            base,
+            quote,
+            price,
+            size,
+        } = create_ask_msg
+        {
+            match ask_storage.load(HYPHENATED_ASK_ID.as_bytes()) {
+                Ok(stored_order) => {
+                    assert_eq!(
+                        stored_order,
+                        AskOrderV1 {
+                            base,
+                            class: AskOrderClass::Basic,
+                            id: HYPHENATED_ASK_ID.into(),
+                            owner: Addr::unchecked("asker"),
+                            price,
+                            quote,
+                            size
+                        }
+                    )
+                }
+                _ => {
+                    panic!("ask order was not found in storage")
+                }
+            }
+        } else {
+            panic!("ask_message is not a CreateAsk type. this is bad.")
+        }
+    }
+}

--- a/src/tests/execute/create_ask_tests.rs
+++ b/src/tests/execute/create_ask_tests.rs
@@ -1,44 +1,18 @@
 #[cfg(test)]
 mod create_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::setup_test_base;
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, Uint128};
+    use cosmwasm_std::{coins, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn create_ask_valid_data_unhyphenated_id() {
+    fn create_ask_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_1".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        deps.querier.with_attributes(
-            "asker",
-            &[
-                ("ask_tag_1", "ask_tag_1_value", "String"),
-                ("ask_tag_2", "ask_tag_2_value", "String"),
-            ],
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // create ask data
         let create_ask_msg = ExecuteMsg::CreateAsk {
@@ -60,60 +34,6 @@ mod create_ask_tests {
         );
 
         // verify create ask response
-        match create_ask_response {
-            Ok(response) => {
-                assert_eq!(response.attributes.len(), 8);
-                assert_eq!(response.attributes[0], attr("action", "create_ask"));
-                assert_eq!(response.attributes[1], attr("id", HYPHENATED_ASK_ID));
-                assert_eq!(
-                    response.attributes[2],
-                    attr(
-                        "class",
-                        serde_json::to_string(&AskOrderClass::Basic {}).unwrap()
-                    )
-                );
-                assert_eq!(response.attributes[3], attr("target_base", "base_1"));
-                assert_eq!(response.attributes[4], attr("base", "base_1"));
-                assert_eq!(response.attributes[5], attr("quote", "quote_1"));
-                assert_eq!(response.attributes[6], attr("price", "2.5"));
-                assert_eq!(response.attributes[7], attr("size", "200"));
-            }
-            Err(error) => {
-                panic!("failed to create ask: {:?}", error)
-            }
-        }
-
-        // verify ask order stored
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        if let ExecuteMsg::CreateAsk {
-            id,
-            base,
-            quote,
-            price,
-            size,
-        } = create_ask_msg
-        {
-            match ask_storage.load(HYPHENATED_ASK_ID.as_bytes()) {
-                Ok(stored_order) => {
-                    assert_eq!(
-                        stored_order,
-                        AskOrderV1 {
-                            base,
-                            class: AskOrderClass::Basic,
-                            id: HYPHENATED_ASK_ID.into(),
-                            owner: Addr::unchecked("asker"),
-                            price,
-                            quote,
-                            size
-                        }
-                    )
-                }
-                _ => {
-                    panic!("ask order was not found in storage")
-                }
-            }
-        } else {
-            panic!("ask_message is not a CreateAsk type. this is bad.")
-        }
+        validate_execute_invalid_id_field(create_ask_response)
     }
 }

--- a/src/tests/execute/create_bid_tests.rs
+++ b/src/tests/execute/create_bid_tests.rs
@@ -1,44 +1,18 @@
 #[cfg(test)]
 mod create_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
-    use crate::tests::test_utils::setup_test_base;
+    use crate::tests::test_constants::UNHYPHENATED_BID_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, Coin, Uint128};
+    use cosmwasm_std::{coins, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
     fn create_bid_valid_data_unhyphenated() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_1".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        deps.querier.with_attributes(
-            "bidder",
-            &[
-                ("bid_tag_1", "bid_tag_1_value", "String"),
-                ("bid_tag_2", "bid_tag_2_value", "String"),
-            ],
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // create bid data
         let create_bid_msg = ExecuteMsg::CreateBid {
@@ -62,62 +36,6 @@ mod create_bid_tests {
         );
 
         // verify execute create bid response
-        match create_bid_response {
-            Ok(response) => {
-                assert_eq!(response.attributes.len(), 8);
-                assert_eq!(response.attributes[0], attr("action", "create_bid"));
-                assert_eq!(response.attributes[1], attr("base", "base_1"));
-                assert_eq!(response.attributes[2], attr("id", HYPHENATED_BID_ID));
-                assert_eq!(response.attributes[3], attr("fee", "None"));
-                assert_eq!(response.attributes[4], attr("price", "2.5"));
-                assert_eq!(response.attributes[5], attr("quote", "quote_1"));
-                assert_eq!(response.attributes[6], attr("quote_size", "250"));
-                assert_eq!(response.attributes[7], attr("size", "100"));
-            }
-            Err(error) => {
-                panic!("failed to create bid: {:?}", error)
-            }
-        }
-
-        // verify bid order stored
-        let bid_storage = get_bid_storage_read(&deps.storage);
-        if let ExecuteMsg::CreateBid {
-            id,
-            base,
-            fee,
-            quote,
-            quote_size,
-            price,
-            size,
-        } = create_bid_msg
-        {
-            match bid_storage.load(HYPHENATED_BID_ID.as_bytes()) {
-                Ok(stored_order) => {
-                    assert_eq!(
-                        stored_order,
-                        BidOrderV2 {
-                            base: Coin {
-                                amount: size,
-                                denom: base,
-                            },
-                            events: vec![],
-                            fee,
-                            id: HYPHENATED_BID_ID.into(), // Should be hyphenated
-                            owner: bidder_info.sender,
-                            price,
-                            quote: Coin {
-                                amount: quote_size,
-                                denom: quote,
-                            },
-                        }
-                    )
-                }
-                _ => {
-                    panic!("bid order was not found in storage")
-                }
-            }
-        } else {
-            panic!("bid_message is not a CreateBid type. this is bad.")
-        }
+        validate_execute_invalid_id_field(create_bid_response)
     }
 }

--- a/src/tests/execute/create_bid_tests.rs
+++ b/src/tests/execute/create_bid_tests.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod create_bid_tests {
+    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_utils::setup_test_base;
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, Coin, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn create_bid_valid_data_unhyphenated() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_1".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        deps.querier.with_attributes(
+            "bidder",
+            &[
+                ("bid_tag_1", "bid_tag_1_value", "String"),
+                ("bid_tag_2", "bid_tag_2_value", "String"),
+            ],
+        );
+
+        // create bid data
+        let create_bid_msg = ExecuteMsg::CreateBid {
+            id: UNHYPHENATED_BID_ID.to_string(), // Unhyphenated UUID
+            base: "base_1".into(),
+            fee: None,
+            price: "2.5".into(),
+            quote: "quote_1".into(),
+            quote_size: Uint128::new(250),
+            size: Uint128::new(100),
+        };
+
+        let bidder_info = mock_info("bidder", &coins(250, "quote_1"));
+
+        // execute create bid
+        let create_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            bidder_info.clone(),
+            create_bid_msg.clone(),
+        );
+
+        // verify execute create bid response
+        match create_bid_response {
+            Ok(response) => {
+                assert_eq!(response.attributes.len(), 8);
+                assert_eq!(response.attributes[0], attr("action", "create_bid"));
+                assert_eq!(response.attributes[1], attr("base", "base_1"));
+                assert_eq!(response.attributes[2], attr("id", HYPHENATED_BID_ID));
+                assert_eq!(response.attributes[3], attr("fee", "None"));
+                assert_eq!(response.attributes[4], attr("price", "2.5"));
+                assert_eq!(response.attributes[5], attr("quote", "quote_1"));
+                assert_eq!(response.attributes[6], attr("quote_size", "250"));
+                assert_eq!(response.attributes[7], attr("size", "100"));
+            }
+            Err(error) => {
+                panic!("failed to create bid: {:?}", error)
+            }
+        }
+
+        // verify bid order stored
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        if let ExecuteMsg::CreateBid {
+            id,
+            base,
+            fee,
+            quote,
+            quote_size,
+            price,
+            size,
+        } = create_bid_msg
+        {
+            match bid_storage.load(HYPHENATED_BID_ID.as_bytes()) {
+                Ok(stored_order) => {
+                    assert_eq!(
+                        stored_order,
+                        BidOrderV2 {
+                            base: Coin {
+                                amount: size,
+                                denom: base,
+                            },
+                            events: vec![],
+                            fee,
+                            id: HYPHENATED_BID_ID.into(), // Should be hyphenated
+                            owner: bidder_info.sender,
+                            price,
+                            quote: Coin {
+                                amount: quote_size,
+                                denom: quote,
+                            },
+                        }
+                    )
+                }
+                _ => {
+                    panic!("bid order was not found in storage")
+                }
+            }
+        } else {
+            panic!("bid_message is not a CreateBid type. this is bad.")
+        }
+    }
+}

--- a/src/tests/execute/execute_match_tests.rs
+++ b/src/tests/execute/execute_match_tests.rs
@@ -1,75 +1,20 @@
 #[cfg(test)]
 mod execute_match_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
-    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
+    use crate::error::ContractError;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{
-        HYPHENATED_ASK_ID, HYPHENATED_BID_ID, UNHYPHENATED_ASK_ID, UNHYPHENATED_BID_ID,
-    };
-    use crate::tests::test_utils::{setup_test_base, store_test_ask, store_test_bid};
+    use crate::tests::test_constants::{UNHYPHENATED_ASK_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use cosmwasm_std::Uint128;
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn execute_valid_data_unhyphenated_id() {
+    fn execute_invalid_input_unhyphenated_ids() {
         // setup
         let mut deps = mock_dependencies(&[]);
         let mock_env = mock_env();
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        store_test_ask(
-            &mut deps.storage,
-            &AskOrderV1 {
-                base: "base_1".into(),
-                class: AskOrderClass::Basic,
-                id: HYPHENATED_ASK_ID.into(),
-                owner: Addr::unchecked("asker"),
-                price: "2".into(),
-                quote: "quote_1".into(),
-                size: Uint128::new(100),
-            },
-        );
-
-        // store valid bid order
-        store_test_bid(
-            &mut deps.storage,
-            &BidOrderV2 {
-                id: HYPHENATED_BID_ID.into(),
-                owner: Addr::unchecked("bidder"),
-                base: Coin {
-                    amount: Uint128::new(100),
-                    denom: "base_1".into(),
-                },
-                events: vec![],
-                fee: None,
-                quote: Coin {
-                    amount: Uint128::new(200),
-                    denom: "quote_1".into(),
-                },
-                price: "2".into(),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // execute on matched ask order and bid order
         let execute_msg = ExecuteMsg::ExecuteMatch {
@@ -88,49 +33,14 @@ mod execute_match_tests {
 
         // validate execute response
         match execute_response {
-            Err(error) => panic!("unexpected error: {:?}", error),
-            Ok(execute_response) => {
-                assert_eq!(execute_response.attributes.len(), 9);
-                assert_eq!(execute_response.attributes[0], attr("action", "execute"));
-                assert_eq!(
-                    execute_response.attributes[1],
-                    attr("ask_id", HYPHENATED_ASK_ID)
-                );
-                assert_eq!(
-                    execute_response.attributes[2],
-                    attr("bid_id", HYPHENATED_BID_ID)
-                );
-                assert_eq!(execute_response.attributes[3], attr("base", "base_1"));
-                assert_eq!(execute_response.attributes[4], attr("quote", "quote_1"));
-                assert_eq!(execute_response.attributes[5], attr("price", "2"));
-                assert_eq!(execute_response.attributes[6], attr("size", "100"));
-                assert_eq!(execute_response.attributes[7], attr("ask_fee", "0"));
-                assert_eq!(execute_response.attributes[8], attr("bid_fee", "0"));
-
-                assert_eq!(execute_response.messages.len(), 2);
-                assert_eq!(
-                    execute_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "asker".into(),
-                        amount: coins(200, "quote_1"),
-                    })
-                );
-                assert_eq!(
-                    execute_response.messages[1].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "bidder".into(),
-                        amount: coins(100, "base_1"),
-                    })
-                );
-            }
+            Ok(_) => panic!("expected error, but ok"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert!(fields.contains(&"ask_id".into()));
+                    assert!(fields.contains(&"bid_id".into()));
+                }
+                error => panic!("unexpected error: {:?}", error),
+            },
         }
-
-        // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
-
-        // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
     }
 }

--- a/src/tests/execute/execute_match_tests.rs
+++ b/src/tests/execute/execute_match_tests.rs
@@ -1,0 +1,136 @@
+#[cfg(test)]
+mod execute_match_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{
+        HYPHENATED_ASK_ID, HYPHENATED_BID_ID, UNHYPHENATED_ASK_ID, UNHYPHENATED_BID_ID,
+    };
+    use crate::tests::test_utils::{setup_test_base, store_test_ask, store_test_bid};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn execute_valid_data_unhyphenated_id() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+        let mock_env = mock_env();
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "base_1".into(),
+                class: AskOrderClass::Basic,
+                id: HYPHENATED_ASK_ID.into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        // store valid bid order
+        store_test_bid(
+            &mut deps.storage,
+            &BidOrderV2 {
+                id: HYPHENATED_BID_ID.into(),
+                owner: Addr::unchecked("bidder"),
+                base: Coin {
+                    amount: Uint128::new(100),
+                    denom: "base_1".into(),
+                },
+                events: vec![],
+                fee: None,
+                quote: Coin {
+                    amount: Uint128::new(200),
+                    denom: "quote_1".into(),
+                },
+                price: "2".into(),
+            },
+        );
+
+        // execute on matched ask order and bid order
+        let execute_msg = ExecuteMsg::ExecuteMatch {
+            ask_id: UNHYPHENATED_ASK_ID.into(),
+            bid_id: UNHYPHENATED_BID_ID.into(),
+            price: "2".into(),
+            size: Uint128::new(100),
+        };
+
+        let execute_response = execute(
+            deps.as_mut(),
+            mock_env,
+            mock_info("exec_1", &[]),
+            execute_msg,
+        );
+
+        // validate execute response
+        match execute_response {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(execute_response) => {
+                assert_eq!(execute_response.attributes.len(), 9);
+                assert_eq!(execute_response.attributes[0], attr("action", "execute"));
+                assert_eq!(
+                    execute_response.attributes[1],
+                    attr("ask_id", HYPHENATED_ASK_ID)
+                );
+                assert_eq!(
+                    execute_response.attributes[2],
+                    attr("bid_id", HYPHENATED_BID_ID)
+                );
+                assert_eq!(execute_response.attributes[3], attr("base", "base_1"));
+                assert_eq!(execute_response.attributes[4], attr("quote", "quote_1"));
+                assert_eq!(execute_response.attributes[5], attr("price", "2"));
+                assert_eq!(execute_response.attributes[6], attr("size", "100"));
+                assert_eq!(execute_response.attributes[7], attr("ask_fee", "0"));
+                assert_eq!(execute_response.attributes[8], attr("bid_fee", "0"));
+
+                assert_eq!(execute_response.messages.len(), 2);
+                assert_eq!(
+                    execute_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "asker".into(),
+                        amount: coins(200, "quote_1"),
+                    })
+                );
+                assert_eq!(
+                    execute_response.messages[1].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "bidder".into(),
+                        amount: coins(100, "base_1"),
+                    })
+                );
+            }
+        }
+
+        // verify ask order removed from storage
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+
+        // verify bid order removed from storage
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/expire_ask_tests.rs
+++ b/src/tests/execute/expire_ask_tests.rs
@@ -1,50 +1,17 @@
 #[cfg(test)]
 mod expire_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn expire_ask_valid_unhyphenated_id() {
+    fn expire_ask_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        store_test_ask(
-            &mut deps.storage,
-            &AskOrderV1 {
-                base: "base_1".into(),
-                class: AskOrderClass::Basic,
-                id: HYPHENATED_ASK_ID.into(),
-                owner: Addr::unchecked("asker"),
-                price: "2".into(),
-                quote: "quote_1".into(),
-                size: Uint128::new(100),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // expire ask order
         let exec_info = mock_info("exec_1", &[]);
@@ -54,39 +21,6 @@ mod expire_ask_tests {
         };
         let expire_ask_response = execute(deps.as_mut(), mock_env(), exec_info, expire_ask_msg);
 
-        match expire_ask_response {
-            Ok(expire_ask_response) => {
-                assert_eq!(expire_ask_response.attributes.len(), 4);
-                assert_eq!(
-                    expire_ask_response.attributes[0],
-                    attr("action", "expire_ask")
-                );
-                assert_eq!(
-                    expire_ask_response.attributes[1],
-                    attr("id", HYPHENATED_ASK_ID)
-                );
-                assert_eq!(
-                    expire_ask_response.attributes[2],
-                    attr("reverse_size", "100")
-                );
-                assert_eq!(
-                    expire_ask_response.attributes[3],
-                    attr("order_open", "false")
-                );
-                assert_eq!(expire_ask_response.messages.len(), 1);
-                assert_eq!(
-                    expire_ask_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "asker".to_string(),
-                        amount: coins(100, "base_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        validate_execute_invalid_id_field(expire_ask_response)
     }
 }

--- a/src/tests/execute/expire_ask_tests.rs
+++ b/src/tests/execute/expire_ask_tests.rs
@@ -1,0 +1,92 @@
+#[cfg(test)]
+mod expire_ask_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn expire_ask_valid_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "base_1".into(),
+                class: AskOrderClass::Basic,
+                id: HYPHENATED_ASK_ID.into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        // expire ask order
+        let exec_info = mock_info("exec_1", &[]);
+
+        let expire_ask_msg = ExecuteMsg::ExpireAsk {
+            id: UNHYPHENATED_ASK_ID.to_string(),
+        };
+        let expire_ask_response = execute(deps.as_mut(), mock_env(), exec_info, expire_ask_msg);
+
+        match expire_ask_response {
+            Ok(expire_ask_response) => {
+                assert_eq!(expire_ask_response.attributes.len(), 4);
+                assert_eq!(
+                    expire_ask_response.attributes[0],
+                    attr("action", "expire_ask")
+                );
+                assert_eq!(
+                    expire_ask_response.attributes[1],
+                    attr("id", HYPHENATED_ASK_ID)
+                );
+                assert_eq!(
+                    expire_ask_response.attributes[2],
+                    attr("reverse_size", "100")
+                );
+                assert_eq!(
+                    expire_ask_response.attributes[3],
+                    attr("order_open", "false")
+                );
+                assert_eq!(expire_ask_response.messages.len(), 1);
+                assert_eq!(
+                    expire_ask_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "asker".to_string(),
+                        amount: coins(100, "base_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify ask order removed from storage
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/expire_bid_tests.rs
+++ b/src/tests/execute/expire_bid_tests.rs
@@ -1,0 +1,99 @@
+#[cfg(test)]
+mod expire_bid_tests {
+    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn expire_bid_valid() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // create bid data
+        store_test_bid(
+            &mut deps.storage,
+            &BidOrderV2 {
+                base: Coin {
+                    amount: Uint128::new(100),
+                    denom: "base_1".into(),
+                },
+                events: vec![],
+                fee: None,
+                id: HYPHENATED_BID_ID.into(),
+                owner: Addr::unchecked("bidder"),
+                price: "2".into(),
+                quote: Coin {
+                    amount: Uint128::new(200),
+                    denom: "quote_1".into(),
+                },
+            },
+        );
+
+        // expire bid order
+        let exec_info = mock_info("exec_1", &[]);
+
+        let expire_bid_msg = ExecuteMsg::ExpireBid {
+            id: UNHYPHENATED_BID_ID.to_string(),
+        };
+
+        let expire_bid_response = execute(deps.as_mut(), mock_env(), exec_info, expire_bid_msg);
+
+        match expire_bid_response {
+            Ok(expire_bid_response) => {
+                assert_eq!(expire_bid_response.attributes.len(), 4);
+                assert_eq!(
+                    expire_bid_response.attributes[0],
+                    attr("action", "expire_bid")
+                );
+                assert_eq!(
+                    expire_bid_response.attributes[1],
+                    attr("id", HYPHENATED_BID_ID)
+                );
+                assert_eq!(
+                    expire_bid_response.attributes[2],
+                    attr("reverse_size", "100")
+                );
+                assert_eq!(
+                    expire_bid_response.attributes[3],
+                    attr("order_open", "false")
+                );
+                assert_eq!(expire_bid_response.messages.len(), 1);
+                assert_eq!(
+                    expire_bid_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "bidder".to_string(),
+                        amount: coins(200, "quote_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify bid order removed from storage
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/expire_bid_tests.rs
+++ b/src/tests/execute/expire_bid_tests.rs
@@ -1,56 +1,17 @@
 #[cfg(test)]
 mod expire_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use crate::tests::test_constants::UNHYPHENATED_BID_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn expire_bid_valid() {
+    fn expire_bid_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // create bid data
-        store_test_bid(
-            &mut deps.storage,
-            &BidOrderV2 {
-                base: Coin {
-                    amount: Uint128::new(100),
-                    denom: "base_1".into(),
-                },
-                events: vec![],
-                fee: None,
-                id: HYPHENATED_BID_ID.into(),
-                owner: Addr::unchecked("bidder"),
-                price: "2".into(),
-                quote: Coin {
-                    amount: Uint128::new(200),
-                    denom: "quote_1".into(),
-                },
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // expire bid order
         let exec_info = mock_info("exec_1", &[]);
@@ -61,39 +22,6 @@ mod expire_bid_tests {
 
         let expire_bid_response = execute(deps.as_mut(), mock_env(), exec_info, expire_bid_msg);
 
-        match expire_bid_response {
-            Ok(expire_bid_response) => {
-                assert_eq!(expire_bid_response.attributes.len(), 4);
-                assert_eq!(
-                    expire_bid_response.attributes[0],
-                    attr("action", "expire_bid")
-                );
-                assert_eq!(
-                    expire_bid_response.attributes[1],
-                    attr("id", HYPHENATED_BID_ID)
-                );
-                assert_eq!(
-                    expire_bid_response.attributes[2],
-                    attr("reverse_size", "100")
-                );
-                assert_eq!(
-                    expire_bid_response.attributes[3],
-                    attr("order_open", "false")
-                );
-                assert_eq!(expire_bid_response.messages.len(), 1);
-                assert_eq!(
-                    expire_bid_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "bidder".to_string(),
-                        amount: coins(200, "quote_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        validate_execute_invalid_id_field(expire_bid_response)
     }
 }

--- a/src/tests/execute/reject_ask_tests.rs
+++ b/src/tests/execute/reject_ask_tests.rs
@@ -1,0 +1,93 @@
+#[cfg(test)]
+mod reject_ask_tests {
+    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn reject_ask_valid_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "base_1".into(),
+                class: AskOrderClass::Basic,
+                id: HYPHENATED_ASK_ID.into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        // expire ask order
+        let exec_info = mock_info("exec_1", &[]);
+
+        let reject_ask_msg = ExecuteMsg::RejectAsk {
+            id: UNHYPHENATED_ASK_ID.to_string(),
+            size: None,
+        };
+        let reject_ask_response = execute(deps.as_mut(), mock_env(), exec_info, reject_ask_msg);
+
+        match reject_ask_response {
+            Ok(reject_ask_response) => {
+                assert_eq!(reject_ask_response.attributes.len(), 4);
+                assert_eq!(
+                    reject_ask_response.attributes[0],
+                    attr("action", "reject_ask")
+                );
+                assert_eq!(
+                    reject_ask_response.attributes[1],
+                    attr("id", HYPHENATED_ASK_ID)
+                );
+                assert_eq!(
+                    reject_ask_response.attributes[2],
+                    attr("reverse_size", "100")
+                );
+                assert_eq!(
+                    reject_ask_response.attributes[3],
+                    attr("order_open", "false")
+                );
+                assert_eq!(reject_ask_response.messages.len(), 1);
+                assert_eq!(
+                    reject_ask_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "asker".to_string(),
+                        amount: coins(100, "base_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify ask order removed from storage
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/reject_ask_tests.rs
+++ b/src/tests/execute/reject_ask_tests.rs
@@ -1,50 +1,17 @@
 #[cfg(test)]
 mod reject_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_ask};
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn reject_ask_valid_unhyphenated_id() {
+    fn reject_ask_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        store_test_ask(
-            &mut deps.storage,
-            &AskOrderV1 {
-                base: "base_1".into(),
-                class: AskOrderClass::Basic,
-                id: HYPHENATED_ASK_ID.into(),
-                owner: Addr::unchecked("asker"),
-                price: "2".into(),
-                quote: "quote_1".into(),
-                size: Uint128::new(100),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // expire ask order
         let exec_info = mock_info("exec_1", &[]);
@@ -55,39 +22,6 @@ mod reject_ask_tests {
         };
         let reject_ask_response = execute(deps.as_mut(), mock_env(), exec_info, reject_ask_msg);
 
-        match reject_ask_response {
-            Ok(reject_ask_response) => {
-                assert_eq!(reject_ask_response.attributes.len(), 4);
-                assert_eq!(
-                    reject_ask_response.attributes[0],
-                    attr("action", "reject_ask")
-                );
-                assert_eq!(
-                    reject_ask_response.attributes[1],
-                    attr("id", HYPHENATED_ASK_ID)
-                );
-                assert_eq!(
-                    reject_ask_response.attributes[2],
-                    attr("reverse_size", "100")
-                );
-                assert_eq!(
-                    reject_ask_response.attributes[3],
-                    attr("order_open", "false")
-                );
-                assert_eq!(reject_ask_response.messages.len(), 1);
-                assert_eq!(
-                    reject_ask_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "asker".to_string(),
-                        amount: coins(100, "base_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        validate_execute_invalid_id_field(reject_ask_response)
     }
 }

--- a/src/tests/execute/reject_bid_tests.rs
+++ b/src/tests/execute/reject_bid_tests.rs
@@ -1,0 +1,100 @@
+#[cfg(test)]
+mod reject_bid_tests {
+    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
+    use crate::contract::execute;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::ExecuteMsg;
+    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn reject_bid_valid_unhyphenated_id() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // create bid data
+        store_test_bid(
+            &mut deps.storage,
+            &BidOrderV2 {
+                id: HYPHENATED_BID_ID.into(),
+                owner: Addr::unchecked("bidder"),
+                base: Coin {
+                    amount: Uint128::new(100),
+                    denom: "base_1".into(),
+                },
+                events: vec![],
+                fee: None,
+                quote: Coin {
+                    amount: Uint128::new(200),
+                    denom: "quote_1".into(),
+                },
+                price: "2".into(),
+            },
+        );
+
+        // expire bid order
+        let exec_info = mock_info("exec_1", &[]);
+
+        let reject_bid_msg = ExecuteMsg::RejectBid {
+            id: UNHYPHENATED_BID_ID.to_string(),
+            size: None,
+        };
+
+        let reject_bid_response = execute(deps.as_mut(), mock_env(), exec_info, reject_bid_msg);
+
+        match reject_bid_response {
+            Ok(reject_bid_response) => {
+                assert_eq!(reject_bid_response.attributes.len(), 4);
+                assert_eq!(
+                    reject_bid_response.attributes[0],
+                    attr("action", "reject_bid")
+                );
+                assert_eq!(
+                    reject_bid_response.attributes[1],
+                    attr("id", HYPHENATED_BID_ID)
+                );
+                assert_eq!(
+                    reject_bid_response.attributes[2],
+                    attr("reverse_size", "100")
+                );
+                assert_eq!(
+                    reject_bid_response.attributes[3],
+                    attr("order_open", "false")
+                );
+                assert_eq!(reject_bid_response.messages.len(), 1);
+                assert_eq!(
+                    reject_bid_response.messages[0].msg,
+                    CosmosMsg::Bank(BankMsg::Send {
+                        to_address: "bidder".to_string(),
+                        amount: coins(200, "quote_1"),
+                    })
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // verify bid order removed from storage
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+    }
+}

--- a/src/tests/execute/reject_bid_tests.rs
+++ b/src/tests/execute/reject_bid_tests.rs
@@ -1,56 +1,17 @@
 #[cfg(test)]
 mod reject_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV2};
     use crate::contract::execute;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::ExecuteMsg;
-    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
-    use crate::tests::test_utils::{setup_test_base, store_test_bid};
+    use crate::tests::test_constants::UNHYPHENATED_BID_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_execute_invalid_id_field;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{attr, coins, Addr, BankMsg, Coin, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn reject_bid_valid_unhyphenated_id() {
+    fn reject_bid_invalid_input_unhyphenated_id() {
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // create bid data
-        store_test_bid(
-            &mut deps.storage,
-            &BidOrderV2 {
-                id: HYPHENATED_BID_ID.into(),
-                owner: Addr::unchecked("bidder"),
-                base: Coin {
-                    amount: Uint128::new(100),
-                    denom: "base_1".into(),
-                },
-                events: vec![],
-                fee: None,
-                quote: Coin {
-                    amount: Uint128::new(200),
-                    denom: "quote_1".into(),
-                },
-                price: "2".into(),
-            },
-        );
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // expire bid order
         let exec_info = mock_info("exec_1", &[]);
@@ -62,39 +23,6 @@ mod reject_bid_tests {
 
         let reject_bid_response = execute(deps.as_mut(), mock_env(), exec_info, reject_bid_msg);
 
-        match reject_bid_response {
-            Ok(reject_bid_response) => {
-                assert_eq!(reject_bid_response.attributes.len(), 4);
-                assert_eq!(
-                    reject_bid_response.attributes[0],
-                    attr("action", "reject_bid")
-                );
-                assert_eq!(
-                    reject_bid_response.attributes[1],
-                    attr("id", HYPHENATED_BID_ID)
-                );
-                assert_eq!(
-                    reject_bid_response.attributes[2],
-                    attr("reverse_size", "100")
-                );
-                assert_eq!(
-                    reject_bid_response.attributes[3],
-                    attr("order_open", "false")
-                );
-                assert_eq!(reject_bid_response.messages.len(), 1);
-                assert_eq!(
-                    reject_bid_response.messages[0].msg,
-                    CosmosMsg::Bank(BankMsg::Send {
-                        to_address: "bidder".to_string(),
-                        amount: coins(200, "quote_1"),
-                    })
-                );
-            }
-            Err(error) => panic!("unexpected error: {:?}", error),
-        }
-
-        // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        validate_execute_invalid_id_field(reject_bid_response)
     }
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -1,0 +1,2 @@
+mod get_ask_tests;
+mod get_bid_tests;

--- a/src/tests/query/get_ask_tests.rs
+++ b/src/tests/query/get_ask_tests.rs
@@ -1,0 +1,67 @@
+#[cfg(test)]
+mod get_ask_tests {
+    use crate::ask_order::{get_ask_storage, get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::contract::query;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::QueryMsg;
+    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
+    use crate::tests::test_utils::setup_test_base;
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{to_binary, Addr, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn query_ask_order_unhyphenated_id() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        let ask_order = AskOrderV1 {
+            base: "base_1".into(),
+            class: AskOrderClass::Basic,
+            id: HYPHENATED_ASK_ID.into(),
+            owner: Addr::unchecked("asker"),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(200),
+        };
+
+        let mut ask_storage = get_ask_storage(&mut deps.storage);
+        if let Err(error) = ask_storage.save(HYPHENATED_ASK_ID.as_bytes(), &ask_order) {
+            panic!("unexpected error: {:?}", error)
+        };
+
+        // verify ask order still exists
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_ok());
+
+        // query for ask order
+        let query_ask_response = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::GetAsk {
+                id: UNHYPHENATED_ASK_ID.into(),
+            },
+        );
+
+        assert_eq!(query_ask_response, to_binary(&ask_order));
+    }
+}

--- a/src/tests/query/get_ask_tests.rs
+++ b/src/tests/query/get_ask_tests.rs
@@ -1,57 +1,18 @@
 #[cfg(test)]
 mod get_ask_tests {
-    use crate::ask_order::{get_ask_storage, get_ask_storage_read, AskOrderClass, AskOrderV1};
     use crate::contract::query;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::QueryMsg;
-    use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
-    use crate::tests::test_utils::setup_test_base;
+    use crate::tests::test_constants::UNHYPHENATED_ASK_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_query_invalid_id_field;
     use cosmwasm_std::testing::mock_env;
-    use cosmwasm_std::{to_binary, Addr, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn query_ask_order_unhyphenated_id() {
+    fn query_ask_order_invalid_input_unhyphenated_id() {
         // setup
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid ask order
-        let ask_order = AskOrderV1 {
-            base: "base_1".into(),
-            class: AskOrderClass::Basic,
-            id: HYPHENATED_ASK_ID.into(),
-            owner: Addr::unchecked("asker"),
-            price: "2".into(),
-            quote: "quote_1".into(),
-            size: Uint128::new(200),
-        };
-
-        let mut ask_storage = get_ask_storage(&mut deps.storage);
-        if let Err(error) = ask_storage.save(HYPHENATED_ASK_ID.as_bytes(), &ask_order) {
-            panic!("unexpected error: {:?}", error)
-        };
-
-        // verify ask order still exists
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_ok());
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // query for ask order
         let query_ask_response = query(
@@ -62,6 +23,6 @@ mod get_ask_tests {
             },
         );
 
-        assert_eq!(query_ask_response, to_binary(&ask_order));
+        validate_query_invalid_id_field(query_ask_response)
     }
 }

--- a/src/tests/query/get_bid_tests.rs
+++ b/src/tests/query/get_bid_tests.rs
@@ -1,59 +1,18 @@
 #[cfg(test)]
 mod get_bid_tests {
-    use crate::bid_order::{get_bid_storage, BidOrderV2};
     use crate::contract::query;
-    use crate::contract_info::ContractInfoV3;
     use crate::msg::QueryMsg;
-    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
-    use crate::tests::test_utils::setup_test_base;
+    use crate::tests::test_constants::UNHYPHENATED_BID_ID;
+    use crate::tests::test_setup_utils::setup_test_base_contract_v3;
+    use crate::tests::test_utils::validate_query_invalid_id_field;
     use cosmwasm_std::testing::mock_env;
-    use cosmwasm_std::{to_binary, Addr, Coin, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
-    fn query_bid_order_unhyphenated_id() {
+    fn query_bid_order_invalid_input_unhyphenated_id() {
         // setup
         let mut deps = mock_dependencies(&[]);
-        setup_test_base(
-            &mut deps.storage,
-            &ContractInfoV3 {
-                name: "contract_name".into(),
-                bind_name: "contract_bind_name".into(),
-                base_denom: "base_denom".into(),
-                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
-                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
-                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                ask_fee_info: None,
-                bid_fee_info: None,
-                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
-                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
-                price_precision: Uint128::new(2),
-                size_increment: Uint128::new(100),
-            },
-        );
-
-        // store valid bid order
-        let bid_order = BidOrderV2 {
-            base: Coin {
-                amount: Uint128::new(100),
-                denom: "base_1".into(),
-            },
-            events: vec![],
-            fee: None,
-            id: HYPHENATED_BID_ID.into(),
-            owner: Addr::unchecked("bidder"),
-            price: "2".into(),
-            quote: Coin {
-                amount: Uint128::new(100),
-                denom: "quote_1".into(),
-            },
-        };
-
-        let mut bid_storage = get_bid_storage(&mut deps.storage);
-        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
-            panic!("unexpected error: {:?}", error);
-        };
+        setup_test_base_contract_v3(&mut deps.storage);
 
         // query for bid order
         let query_bid_response = query(
@@ -64,6 +23,6 @@ mod get_bid_tests {
             },
         );
 
-        assert_eq!(query_bid_response, to_binary(&bid_order));
+        validate_query_invalid_id_field(query_bid_response)
     }
 }

--- a/src/tests/query/get_bid_tests.rs
+++ b/src/tests/query/get_bid_tests.rs
@@ -1,0 +1,69 @@
+#[cfg(test)]
+mod get_bid_tests {
+    use crate::bid_order::{get_bid_storage, BidOrderV2};
+    use crate::contract::query;
+    use crate::contract_info::ContractInfoV3;
+    use crate::msg::QueryMsg;
+    use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
+    use crate::tests::test_utils::setup_test_base;
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{to_binary, Addr, Coin, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn query_bid_order_unhyphenated_id() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid bid order
+        let bid_order = BidOrderV2 {
+            base: Coin {
+                amount: Uint128::new(100),
+                denom: "base_1".into(),
+            },
+            events: vec![],
+            fee: None,
+            id: HYPHENATED_BID_ID.into(),
+            owner: Addr::unchecked("bidder"),
+            price: "2".into(),
+            quote: Coin {
+                amount: Uint128::new(100),
+                denom: "quote_1".into(),
+            },
+        };
+
+        let mut bid_storage = get_bid_storage(&mut deps.storage);
+        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
+            panic!("unexpected error: {:?}", error);
+        };
+
+        // query for bid order
+        let query_bid_response = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::GetBid {
+                id: UNHYPHENATED_BID_ID.into(),
+            },
+        );
+
+        assert_eq!(query_bid_response, to_binary(&bid_order));
+    }
+}

--- a/src/tests/test_constants.rs
+++ b/src/tests/test_constants.rs
@@ -1,0 +1,4 @@
+pub const HYPHENATED_ASK_ID: &str = "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367";
+pub const UNHYPHENATED_ASK_ID: &str = "ab5f5a62f6fc46d1aa8451ccc51ec367";
+pub const HYPHENATED_BID_ID: &str = "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b";
+pub const UNHYPHENATED_BID_ID: &str = "c13f8888ca434a64ab1b1ca8d60aa49b";

--- a/src/tests/test_setup_utils.rs
+++ b/src/tests/test_setup_utils.rs
@@ -1,0 +1,45 @@
+use crate::ask_order::{get_ask_storage, AskOrderV1};
+use crate::bid_order::{get_bid_storage, BidOrderV2};
+use crate::contract_info::{set_contract_info, ContractInfoV3};
+use cosmwasm_std::{Addr, Storage, Uint128};
+
+pub fn setup_test_base(storage: &mut dyn Storage, contract_info: &ContractInfoV3) {
+    if let Err(error) = set_contract_info(storage, contract_info) {
+        panic!("unexpected error: {:?}", error)
+    }
+}
+
+pub fn setup_test_base_contract_v3(storage: &mut dyn Storage) {
+    setup_test_base(
+        storage,
+        &ContractInfoV3 {
+            name: "contract_name".into(),
+            bind_name: "contract_bind_name".into(),
+            base_denom: "base_denom".into(),
+            convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+            supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+            approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+            executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+            ask_fee_info: None,
+            bid_fee_info: None,
+            ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+            bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+            price_precision: Uint128::new(2),
+            size_increment: Uint128::new(100),
+        },
+    );
+}
+
+pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
+    let mut ask_storage = get_ask_storage(storage);
+    if let Err(error) = ask_storage.save(ask_order.id.as_bytes(), ask_order) {
+        panic!("unexpected error: {:?}", error)
+    };
+}
+
+pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV2) {
+    let mut bid_storage = get_bid_storage(storage);
+    if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
+        panic!("unexpected error: {:?}", error);
+    };
+}

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -1,24 +1,30 @@
-use crate::ask_order::{get_ask_storage, AskOrderV1};
-use crate::bid_order::{get_bid_storage, BidOrderV2};
-use crate::contract_info::{set_contract_info, ContractInfoV3};
-use cosmwasm_std::Storage;
+use crate::error::ContractError;
+use cosmwasm_std::StdError::GenericErr;
+use cosmwasm_std::{Binary, Response, StdResult};
+use provwasm_std::ProvenanceMsg;
 
-pub fn setup_test_base(storage: &mut dyn Storage, contract_info: &ContractInfoV3) {
-    if let Err(error) = set_contract_info(storage, contract_info) {
-        panic!("unexpected error: {:?}", error)
+pub fn validate_execute_invalid_id_field(
+    execute_response: Result<Response<ProvenanceMsg>, ContractError>,
+) {
+    match execute_response {
+        Ok(_) => panic!("expected error, but ok"),
+        Err(error) => match error {
+            ContractError::InvalidFields { fields } => {
+                assert!(fields.contains(&"id".into()));
+            }
+            error => panic!("unexpected error: {:?}", error),
+        },
     }
 }
 
-pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
-    let mut ask_storage = get_ask_storage(storage);
-    if let Err(error) = ask_storage.save(ask_order.id.as_bytes(), ask_order) {
-        panic!("unexpected error: {:?}", error)
-    };
-}
-
-pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV2) {
-    let mut bid_storage = get_bid_storage(storage);
-    if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
-        panic!("unexpected error: {:?}", error);
-    };
+pub fn validate_query_invalid_id_field(query_response: StdResult<Binary>) {
+    match query_response {
+        Ok(_) => panic!("expected error, but ok"),
+        Err(error) => match error {
+            GenericErr { msg } => {
+                assert_eq!(msg, "Invalid fields: [\"id\"]")
+            }
+            error => panic!("unexpected error: {:?}", error),
+        },
+    }
 }

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -1,0 +1,24 @@
+use crate::ask_order::{get_ask_storage, AskOrderV1};
+use crate::bid_order::{get_bid_storage, BidOrderV2};
+use crate::contract_info::{set_contract_info, ContractInfoV3};
+use cosmwasm_std::Storage;
+
+pub fn setup_test_base(storage: &mut dyn Storage, contract_info: &ContractInfoV3) {
+    if let Err(error) = set_contract_info(storage, contract_info) {
+        panic!("unexpected error: {:?}", error)
+    }
+}
+
+pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
+    let mut ask_storage = get_ask_storage(storage);
+    if let Err(error) = ask_storage.save(ask_order.id.as_bytes(), ask_order) {
+        panic!("unexpected error: {:?}", error)
+    };
+}
+
+pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV2) {
+    let mut bid_storage = get_bid_storage(storage);
+    if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
+        panic!("unexpected error: {:?}", error);
+    };
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,50 @@
+use crate::error::ContractError;
+use uuid::Uuid;
+
+pub fn to_hyphenated_uuid_str(uuid: String) -> Result<String, ContractError> {
+    Ok(Uuid::parse_str(uuid.as_str())
+        .map_err(ContractError::UuidError)?
+        .to_hyphenated()
+        .to_string())
+}
+
+#[cfg(test)]
+mod util_tests {
+    use crate::util::to_hyphenated_uuid_str;
+    const UUID_HYPHENATED: &str = "093231fc-e4b3-4fbc-a441-838787f16933";
+    const UUID_NOT_HYPHENATED: &str = "093231fce4b34fbca441838787f16933";
+
+    #[test]
+    fn to_hyphenated_uuid_not_valid_uuid_input_then_return_err() {
+        let result = to_hyphenated_uuid_str("INVALID_STR".to_string());
+
+        match result {
+            Ok(result_str) => panic!("Expected error: {:?}", result_str),
+            error => {}
+        }
+    }
+
+    #[test]
+    fn to_hyphenated_uuid_input_is_hyphenated_then_return_hyphenated_str() {
+        let result = to_hyphenated_uuid_str(UUID_HYPHENATED.to_string());
+
+        match result {
+            Ok(result_str) => {
+                assert_eq!(result_str, UUID_HYPHENATED)
+            }
+            error => panic!("Unexpected error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn to_hyphenated_uuid_input_not_hyphenated_then_return_hyphenated_str() {
+        let result = to_hyphenated_uuid_str(UUID_NOT_HYPHENATED.to_string());
+
+        match result {
+            Ok(result_str) => {
+                assert_eq!(result_str, UUID_HYPHENATED)
+            }
+            error => panic!("Unexpected error: {:?}", error),
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,16 +1,27 @@
 use crate::error::ContractError;
 use uuid::Uuid;
 
-pub fn to_hyphenated_uuid_str(uuid: String) -> Result<String, ContractError> {
+fn to_hyphenated_uuid_str(uuid: String) -> Result<String, ContractError> {
     Ok(Uuid::parse_str(uuid.as_str())
         .map_err(ContractError::UuidError)?
         .to_hyphenated()
         .to_string())
 }
 
+pub fn is_hyphenated_uuid_str(uuid: &String) -> bool {
+    let hyphenated_uuid_str_result = to_hyphenated_uuid_str(uuid.to_owned());
+    if hyphenated_uuid_str_result.is_err() {
+        return false;
+    }
+    if uuid.ne(&hyphenated_uuid_str_result.unwrap()) {
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod util_tests {
-    use crate::util::to_hyphenated_uuid_str;
+    use crate::util::{is_hyphenated_uuid_str, to_hyphenated_uuid_str};
     const UUID_HYPHENATED: &str = "093231fc-e4b3-4fbc-a441-838787f16933";
     const UUID_NOT_HYPHENATED: &str = "093231fce4b34fbca441838787f16933";
 
@@ -20,7 +31,7 @@ mod util_tests {
 
         match result {
             Ok(result_str) => panic!("Expected error: {:?}", result_str),
-            error => {}
+            _error => {}
         }
     }
 
@@ -45,6 +56,36 @@ mod util_tests {
                 assert_eq!(result_str, UUID_HYPHENATED)
             }
             error => panic!("Unexpected error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn is_hyphenated_uuid_input_not_uuid_then_return_false() {
+        let result = is_hyphenated_uuid_str(&"BAD_INPUT".to_string());
+
+        match result {
+            true => panic!("Expected false"),
+            false => {}
+        }
+    }
+
+    #[test]
+    fn is_hyphenated_uuid_input_not_hyphenated_then_return_false() {
+        let result = is_hyphenated_uuid_str(&UUID_NOT_HYPHENATED.to_string());
+
+        match result {
+            true => panic!("Expected false"),
+            false => {}
+        }
+    }
+
+    #[test]
+    fn is_hyphenated_uuid_input_is_hyphenated_then_return_true() {
+        let result = is_hyphenated_uuid_str(&UUID_HYPHENATED.to_string());
+
+        match result {
+            true => {}
+            false => panic!("Expected true"),
         }
     }
 }


### PR DESCRIPTION
- Don't be alarmed by the size, its almost all tests
- Added `is_hyphenated_uuid_str()` function to validate all uuids are in a hyphenated format.
    - Added function call to all relevant `execute` + `query` `msg.validate()` calls
- Spent some time setting up a new structure for the tests, I wanted to separate files from the massive `contract.rs` file since its extremely annoying to navigate. I know that tests in the same file is pretty normal in Rust, but i think for files with less logic it makes sense.
   - I think we should move all the tests out of `contract.rs` into their respective tests file eventually
   - Just copied the `FUNCTION_valid()` test from `contract.rs` and changed the inputs to be unhyphenated an named tests `FUNCTION_invalid_input_unhyphenated_id()`