### PR TITLE
Allow zero fees to be in request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -533,7 +533,7 @@ fn create_bid(
                 return Err(ContractError::SentFundsOrderMismatch);
             }
         }
-        _ => {
+        None => {
             // If the user did not send fees, make sure the calculated fees was 0
             if calculated_fee_size.ne(&0) {
                 return Err(ContractError::InvalidFeeSize {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -542,60 +542,6 @@ fn create_bid(
             }
         }
     }
-    //
-    // match contract_info.bid_fee_info {
-    //     Some(bid_fee_info) => {
-    //         let bid_fee_rate = Decimal::from_str(&bid_fee_info.rate).map_err(|_| {
-    //             ContractError::InvalidFields {
-    //                 fields: vec![String::from("ContractInfo.bid_fee_info.rate")],
-    //             }
-    //         })?;
-    //
-    //         // if the bid fee rate is 0, there should not be any sent fees
-    //         if bid_fee_rate.eq(&Decimal::zero()) && bid_order.fee.is_some() {
-    //             return Err(ContractError::SentFees);
-    //         }
-    //
-    //         let calculated_fee_size = bid_fee_rate
-    //             .checked_mul(total)
-    //             .ok_or(ContractError::TotalOverflow)?
-    //             .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
-    //             .to_u128()
-    //             .ok_or(ContractError::TotalOverflow)?;
-    //
-    //         match &mut bid_order.fee {
-    //             Some(fee) => {
-    //                 if fee.amount.ne(&Uint128::new(calculated_fee_size)) {
-    //                     return Err(ContractError::InvalidFeeSize {
-    //                         fee_rate: bid_fee_info.rate,
-    //                     });
-    //                 }
-    //                 if fee.denom.ne(&bid_order.quote.denom) {
-    //                     return Err(ContractError::SentFundsOrderMismatch);
-    //                 }
-    //             }
-    //             _ => {
-    //                 return Err(ContractError::InvalidFeeSize {
-    //                     fee_rate: bid_fee_info.rate,
-    //                 })
-    //             }
-    //         }
-    //     }
-    //     None => {
-    //         match &bid_order.fee {
-    //             // Allow for fee.amount of 0 if no fee is required
-    //             Some(fee) => {
-    //                 if fee.denom.ne(&bid_order.quote.denom) {
-    //                     return Err(ContractError::SentFundsOrderMismatch);
-    //                 }
-    //                 if fee.amount.gt(&Uint128::zero()) {
-    //                     return Err(ContractError::SentFees);
-    //                 }
-    //             }
-    //             None => {}
-    //         }
-    //     }
-    // }
 
     // error if order quote is not supported quote denom
     if !&contract_info

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -543,8 +543,14 @@ fn create_bid(
             }
         }
         None => {
-            if bid_order.fee.is_some() {
-                return Err(ContractError::SentFees);
+            match bid_order.fee.to_owned() {
+                // Allow for fee.amount of 0 if no fee is required
+                Some(fee) => {
+                    if fee.amount.gt(&Uint128::zero()) {
+                        return Err(ContractError::SentFees);
+                    }
+                }
+                None => {}
             }
         }
     }
@@ -1652,7 +1658,7 @@ pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult
 // unit tests
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::{Addr, Storage, Uint128};
 
     use super::*;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -503,57 +503,99 @@ fn create_bid(
         return Err(ContractError::SentFundsOrderMismatch);
     }
 
-    // if bid fee exists, calculate and compare to sent fee_size
-    match contract_info.bid_fee_info {
+    // Get the bid fee rate (0 if not set)
+    let bid_fee_rate = match contract_info.bid_fee_info {
         Some(bid_fee_info) => {
-            let bid_fee_rate = Decimal::from_str(&bid_fee_info.rate).map_err(|_| {
-                ContractError::InvalidFields {
-                    fields: vec![String::from("ContractInfo.bid_fee_info.rate")],
-                }
-            })?;
+            Decimal::from_str(&bid_fee_info.rate).map_err(|_| ContractError::InvalidFields {
+                fields: vec![String::from("ContractInfo.bid_fee_info.rate")],
+            })?
+        }
+        None => Decimal::from(0),
+    };
 
-            // if the bid fee rate is 0, there should not be any sent fees
-            if bid_fee_rate.eq(&Decimal::zero()) && bid_order.fee.is_some() {
-                return Err(ContractError::SentFees);
+    // Calculate the expected fees (bid_fee_rate * total)
+    let calculated_fee_size = bid_fee_rate
+        .checked_mul(total)
+        .ok_or(ContractError::TotalOverflow)?
+        .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
+        .to_u128()
+        .ok_or(ContractError::TotalOverflow)?;
+
+    match &mut bid_order.fee {
+        Some(fee) => {
+            // If the user sent fees, then make sure the amount + denom match
+            if fee.amount.ne(&Uint128::new(calculated_fee_size)) {
+                return Err(ContractError::InvalidFeeSize {
+                    fee_rate: bid_fee_rate.to_string(),
+                });
             }
-
-            let calculated_fee_size = bid_fee_rate
-                .checked_mul(total)
-                .ok_or(ContractError::TotalOverflow)?
-                .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
-                .to_u128()
-                .ok_or(ContractError::TotalOverflow)?;
-
-            match &mut bid_order.fee {
-                Some(fee) => {
-                    if fee.amount.ne(&Uint128::new(calculated_fee_size)) {
-                        return Err(ContractError::InvalidFeeSize {
-                            fee_rate: bid_fee_info.rate,
-                        });
-                    }
-                    if fee.denom.ne(&bid_order.quote.denom) {
-                        return Err(ContractError::SentFundsOrderMismatch);
-                    }
-                }
-                _ => {
-                    return Err(ContractError::InvalidFeeSize {
-                        fee_rate: bid_fee_info.rate,
-                    })
-                }
+            if fee.denom.ne(&bid_order.quote.denom) {
+                return Err(ContractError::SentFundsOrderMismatch);
             }
         }
-        None => {
-            match bid_order.fee.to_owned() {
-                // Allow for fee.amount of 0 if no fee is required
-                Some(fee) => {
-                    if fee.amount.gt(&Uint128::zero()) {
-                        return Err(ContractError::SentFees);
-                    }
-                }
-                None => {}
+        _ => {
+            // If the user did not send fees, make sure the calculated fees was 0
+            if calculated_fee_size.ne(&0) {
+                return Err(ContractError::InvalidFeeSize {
+                    fee_rate: bid_fee_rate.to_string(),
+                });
             }
         }
     }
+    //
+    // match contract_info.bid_fee_info {
+    //     Some(bid_fee_info) => {
+    //         let bid_fee_rate = Decimal::from_str(&bid_fee_info.rate).map_err(|_| {
+    //             ContractError::InvalidFields {
+    //                 fields: vec![String::from("ContractInfo.bid_fee_info.rate")],
+    //             }
+    //         })?;
+    //
+    //         // if the bid fee rate is 0, there should not be any sent fees
+    //         if bid_fee_rate.eq(&Decimal::zero()) && bid_order.fee.is_some() {
+    //             return Err(ContractError::SentFees);
+    //         }
+    //
+    //         let calculated_fee_size = bid_fee_rate
+    //             .checked_mul(total)
+    //             .ok_or(ContractError::TotalOverflow)?
+    //             .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
+    //             .to_u128()
+    //             .ok_or(ContractError::TotalOverflow)?;
+    //
+    //         match &mut bid_order.fee {
+    //             Some(fee) => {
+    //                 if fee.amount.ne(&Uint128::new(calculated_fee_size)) {
+    //                     return Err(ContractError::InvalidFeeSize {
+    //                         fee_rate: bid_fee_info.rate,
+    //                     });
+    //                 }
+    //                 if fee.denom.ne(&bid_order.quote.denom) {
+    //                     return Err(ContractError::SentFundsOrderMismatch);
+    //                 }
+    //             }
+    //             _ => {
+    //                 return Err(ContractError::InvalidFeeSize {
+    //                     fee_rate: bid_fee_info.rate,
+    //                 })
+    //             }
+    //         }
+    //     }
+    //     None => {
+    //         match &bid_order.fee {
+    //             // Allow for fee.amount of 0 if no fee is required
+    //             Some(fee) => {
+    //                 if fee.denom.ne(&bid_order.quote.denom) {
+    //                     return Err(ContractError::SentFundsOrderMismatch);
+    //                 }
+    //                 if fee.amount.gt(&Uint128::zero()) {
+    //                     return Err(ContractError::SentFees);
+    //                 }
+    //             }
+    //             None => {}
+    //         }
+    //     }
+    // }
 
     // error if order quote is not supported quote denom
     if !&contract_info

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -202,7 +202,7 @@ impl Validate for ExecuteMsg {
             ExecuteMsg::CreateBid {
                 id,
                 base,
-                fee,
+                fee: _,
                 price,
                 quote,
                 quote_size,
@@ -213,11 +213,6 @@ impl Validate for ExecuteMsg {
                 }
                 if base.is_empty() {
                     invalid_fields.push("base");
-                }
-                if let Some(fee) = fee {
-                    if fee.amount.lt(&Uint128::new(1)) {
-                        invalid_fields.push("fee");
-                    }
                 }
                 if price.is_empty() {
                     invalid_fields.push("price");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,5 +2,6 @@ pub mod execute;
 pub mod instantiate;
 pub mod query;
 pub mod test_constants;
+#[cfg(test)]
 pub mod test_setup_utils;
 pub mod test_utils;

--- a/src/tests/test_constants.rs
+++ b/src/tests/test_constants.rs
@@ -3,5 +3,7 @@ pub const UNHYPHENATED_ASK_ID: &str = "ab5f5a62f6fc46d1aa8451ccc51ec367";
 pub const HYPHENATED_BID_ID: &str = "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b";
 pub const UNHYPHENATED_BID_ID: &str = "c13f8888ca434a64ab1b1ca8d60aa49b";
 pub const BASE_DENOM: &str = "base_denom";
+pub const QUOTE_DENOM_1: &str = "quote_1";
+pub const QUOTE_DENOM_2: &str = "quote_2";
 pub const APPROVER_1: &str = "approver_1";
 pub const APPROVER_2: &str = "approver_2";

--- a/src/tests/test_setup_utils.rs
+++ b/src/tests/test_setup_utils.rs
@@ -3,6 +3,7 @@ use crate::bid_order::{get_bid_storage, BidOrderV2};
 use crate::contract_info::{set_contract_info, ContractInfoV3};
 use crate::tests::test_constants::{APPROVER_1, APPROVER_2, BASE_DENOM};
 use cosmwasm_std::{Addr, Storage, Uint128};
+use provwasm_mocks::ProvenanceMockQuerier;
 
 pub fn setup_test_base(storage: &mut dyn Storage, contract_info: &ContractInfoV3) {
     if let Err(error) = set_contract_info(storage, contract_info) {
@@ -43,4 +44,26 @@ pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV2) {
     if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
         panic!("unexpected error: {:?}", error);
     };
+}
+
+pub fn set_default_required_attributes(
+    querier: &mut ProvenanceMockQuerier,
+    address: &str,
+    ask_attributes: bool,
+    bid_attributes: bool,
+) {
+    let mut attributes: Vec<(&str, &str, &str)> = Vec::new();
+    if ask_attributes {
+        attributes.append(&mut vec![
+            ("ask_tag_1", "ask_tag_1_value", "String"),
+            ("ask_tag_2", "ask_tag_2_value", "String"),
+        ])
+    }
+    if bid_attributes {
+        attributes.append(&mut vec![
+            ("bid_tag_1", "bid_tag_1_value", "String"),
+            ("bid_tag_2", "bid_tag_2_value", "String"),
+        ])
+    }
+    querier.with_attributes(address, &attributes);
 }


### PR DESCRIPTION
Remove the check that does not allow `fee.amount == 0` on a `create_bid` order

Simplified the checking logic a little with the new requirements