### PR TITLE
Fix bid order migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/schema/bid_order_v2.json
+++ b/schema/bid_order_v2.json
@@ -1,20 +1,25 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BidOrderV2",
+  "deprecated": true,
   "type": "object",
   "required": [
     "base",
+    "events",
     "id",
     "owner",
     "price",
-    "quote",
-    "remaining_base",
-    "remaining_fee",
-    "remaining_quote"
+    "quote"
   ],
   "properties": {
     "base": {
       "$ref": "#/definitions/Coin"
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Event"
+      }
     },
     "fee": {
       "anyOf": [
@@ -37,21 +42,135 @@
     },
     "quote": {
       "$ref": "#/definitions/Coin"
-    },
-    "remaining_base": {
-      "$ref": "#/definitions/Uint128"
-    },
-    "remaining_fee": {
-      "$ref": "#/definitions/Uint128"
-    },
-    "remaining_quote": {
-      "$ref": "#/definitions/Uint128"
     }
   },
   "definitions": {
+    "Action": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Fill"
+          ],
+          "properties": {
+            "Fill": {
+              "type": "object",
+              "required": [
+                "base",
+                "price",
+                "quote"
+              ],
+              "properties": {
+                "base": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "fee": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "price": {
+                  "type": "string"
+                },
+                "quote": {
+                  "$ref": "#/definitions/Coin"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Refund"
+          ],
+          "properties": {
+            "Refund": {
+              "type": "object",
+              "required": [
+                "quote"
+              ],
+              "properties": {
+                "fee": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "quote": {
+                  "$ref": "#/definitions/Coin"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Reject"
+          ],
+          "properties": {
+            "Reject": {
+              "type": "object",
+              "required": [
+                "base",
+                "quote"
+              ],
+              "properties": {
+                "base": {
+                  "$ref": "#/definitions/Coin"
+                },
+                "fee": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Coin"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "quote": {
+                  "$ref": "#/definitions/Coin"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
+    },
+    "BlockInfo": {
+      "type": "object",
+      "required": [
+        "height",
+        "time"
+      ],
+      "properties": {
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "time": {
+          "$ref": "#/definitions/Timestamp"
+        }
+      }
     },
     "Coin": {
       "type": "object",
@@ -68,8 +187,35 @@
         }
       }
     },
+    "Event": {
+      "type": "object",
+      "required": [
+        "action",
+        "block_info"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/Action"
+        },
+        "block_info": {
+          "$ref": "#/definitions/BlockInfo"
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/schema/bid_order_v3.json
+++ b/schema/bid_order_v3.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BidOrderV3",
+  "type": "object",
+  "required": [
+    "accumulated_base",
+    "accumulated_fee",
+    "accumulated_quote",
+    "base",
+    "id",
+    "owner",
+    "price",
+    "quote"
+  ],
+  "properties": {
+    "accumulated_base": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "accumulated_fee": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "accumulated_quote": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "base": {
+      "$ref": "#/definitions/Coin"
+    },
+    "fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Coin"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "id": {
+      "type": "string"
+    },
+    "owner": {
+      "$ref": "#/definitions/Addr"
+    },
+    "price": {
+      "type": "string"
+    },
+    "quote": {
+      "$ref": "#/definitions/Coin"
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
- Original version check for BidOrderV2 migration was limited to <0.18.2, but we were on 0.18.2
- Fixed the version check
- Added support to only migrate BidOrderV2 records
   - Skip BidOrderV3 records, if any exist