### PR TITLE
Add 'action' response in modify_contract

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: cargo tarpaulin xml report
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.19.1'
+          version: '0.19.2'
           out-type: Xml
           args: '--ignore-config --ignore-tests'
       - name: upload to codecov.io

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: cargo tarpaulin xml report
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.26.1'
+          version: '0.19.1'
           out-type: Xml
           args: '--ignore-config --ignore-tests'
       - name: upload to codecov.io

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: cargo tarpaulin xml report
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.19.2'
+          version: '0.26.1'
           out-type: Xml
           args: '--ignore-config --ignore-tests'
       - name: upload to codecov.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -47,3 +47,35 @@ impl From<cosmwasm_std::BlockInfo> for BlockInfo {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractAction {
+    Init,
+    Migrate,
+
+    ModifyContract,
+
+    CreateAsk,
+    ApproveAsk,
+    CancelAsk,
+    ExpireAsk,
+    RejectAsk,
+
+    CreateBid,
+    CancelBid,
+    ExpireBid,
+    RejectBid,
+
+    Execute, // Execute match
+}
+
+impl ToString for ContractAction {
+    fn to_string(&self) -> String {
+        serde_json::to_value(&self)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1120,7 +1120,7 @@ fn modify_contract(
         bid_required_attributes,
     )?;
 
-    let response = Response::new();
+    let response = Response::new().add_attribute("action", "modify_contract");
 
     Ok(response)
 }

--- a/src/tests/execute/execute_modify_tests.rs
+++ b/src/tests/execute/execute_modify_tests.rs
@@ -9,8 +9,13 @@ mod execute_modify_test {
     use crate::tests::test_setup_utils::{setup_test_base, store_test_ask};
     use crate::version_info::{set_version_info, VersionInfoV1};
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{coin, Addr, MessageInfo, Uint128};
+    use cosmwasm_std::{coin, Addr, MessageInfo, Response, Uint128};
     use provwasm_mocks::mock_dependencies;
+    use provwasm_std::ProvenanceMsg;
+
+    fn get_expected_modify_contract_response() -> Response<ProvenanceMsg> {
+        Response::new().add_attribute("action", "modify_contract")
+    }
 
     #[test]
     fn execute_modify_contract_valid() {
@@ -78,7 +83,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
 
@@ -603,7 +610,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
 
@@ -853,7 +862,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
 
@@ -1007,7 +1018,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
     }
@@ -1194,7 +1207,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
 
@@ -1306,8 +1321,10 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
-            Ok(_) => {}
         }
 
         let contract_info = get_contract_info(&deps.storage);
@@ -1643,7 +1660,9 @@ mod execute_modify_test {
         let modify_contract_response =
             execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
         match modify_contract_response {
-            Ok(_) => {}
+            Ok(response) => {
+                assert_eq!(response, get_expected_modify_contract_response())
+            }
             Err(error) => panic!("unexpected error: {:?}", error),
         }
 


### PR DESCRIPTION
- Adding metadata on the `Response` to be able to easily discern the `TxEvent` type from the EventStream.
- Bumped version to `0.19.2`