### PR TITLE
Migrate Bid storage from Bucket to Map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+
+[[package]]
 name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,9 +190,9 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
+checksum = "871ce1d5a4b00ed1741f84b377eec19fadd81a904a227bc1e268d76539d26f5e"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -197,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
+checksum = "7ce8b44b45a7c8c6d6f770cd0a51458c2445c7c15b6115e1d215fa35c77b305c"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -230,11 +236,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
+checksum = "da78abcf059181e8cb01e95e5003cf64fe95dde6c72b3fe37e5cabc75cdba32a"
 dependencies = [
  "base64",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -245,14 +252,13 @@ dependencies = [
  "serde-json-wasm",
  "sha2 0.10.6",
  "thiserror",
- "uint",
 ]
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639bc36408bc1ac45e3323166ceeb8f0b91b55a941c4ad59d389829002fbbd94"
+checksum = "b52be0d56b78f502f3acb75e40908a0d04d9f265b6beb0f86b36ec2ece048748"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -266,12 +272,6 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a5083c258acd68386734f428a5a171b29f7d733151ae83090c6fcc9417ffa"
+checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -882,12 +882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,18 +943,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ overflow-checks = true
 #backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.2.3" }
-cosmwasm-storage = { version = "1.2.3", features = ["iterator"] }
-cw-storage-plus = { version = "1.0.1" }
+cosmwasm-std = { version = "1.3.3" }
+cw-storage-plus = { version = "1.1.0" }
+cosmwasm-storage = { version = "1.3.3", features = ["iterator"] }
 provwasm-std = { version = "1.1.2" }
 rust_decimal = "1.29.0"
 schemars = "0.8.11"

--- a/src/bid_order.rs
+++ b/src/bid_order.rs
@@ -240,7 +240,6 @@ pub fn migrate_bid_orders(
         // Load the BidOrderV2 items, convert to BidOrderV3, save as BidOrderV3
         for existing_bid_order_v2_id in existing_bid_order_v2_ids {
             let bid_order_v2: BidOrderV2 = BIDS_V2.load(store, &existing_bid_order_v2_id)?;
-            // bucket_read(store, NAMESPACE_ORDER_BID).load(&existing_bid_order_v2_id)?;
             let bid_order_v3: BidOrderV3 = bid_order_v2.into();
 
             BIDS_V3.save(store, &existing_bid_order_v2_id, &bid_order_v3)?

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1062,9 +1062,7 @@ fn modify_contract(
         }
     }
 
-    // Option 1 (Requires migrating Bucket -> Map)
     let contains_bid = !BIDS_V3.is_empty(deps.storage);
-
     if contains_bid {
         match &bid_required_attributes {
             None => {}

--- a/src/tests/execute/cancel_bid_tests.rs
+++ b/src/tests/execute/cancel_bid_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod cancel_bid_tests {
     use crate::ask_order::{AskOrderClass, AskOrderV1};
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -89,8 +89,9 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -166,8 +167,9 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -292,9 +294,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -401,9 +405,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -503,9 +509,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -647,9 +655,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -893,7 +903,6 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(bid_id.as_bytes()).is_err());
+        assert!(BIDS_V3.load(&deps.storage, bid_id.as_bytes()).is_err());
     }
 }

--- a/src/tests/execute/create_bid_tests.rs
+++ b/src/tests/execute/create_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod create_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -137,7 +137,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -148,7 +147,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -283,7 +285,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -294,7 +295,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -407,7 +411,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let ask_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -418,7 +421,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -541,7 +547,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -552,7 +557,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -675,7 +683,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -686,7 +693,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -809,7 +819,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -820,7 +829,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -980,7 +992,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -991,7 +1002,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -1186,9 +1200,10 @@ mod create_bid_tests {
         }
 
         // verify bid order stored is the original order
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/execute/execute_match_tests.rs
+++ b/src/tests/execute/execute_match_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod execute_match_tests {
     use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -136,9 +136,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 
@@ -281,9 +283,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -407,9 +411,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -533,9 +539,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -662,9 +670,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -781,9 +791,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -921,9 +933,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1063,9 +1077,11 @@ mod execute_match_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1183,8 +1199,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1355,8 +1373,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1539,8 +1559,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1703,9 +1725,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1841,8 +1865,10 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -2025,8 +2051,10 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -2230,9 +2258,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2357,9 +2387,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2496,9 +2528,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2659,9 +2693,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2822,9 +2858,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3019,9 +3057,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3230,9 +3270,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3406,9 +3448,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3652,9 +3696,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -4184,9 +4230,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order still exists
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 
@@ -4279,9 +4327,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order still exists
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 }

--- a/src/tests/execute/execute_modify_tests.rs
+++ b/src/tests/execute/execute_modify_tests.rs
@@ -641,6 +641,23 @@ mod execute_modify_test {
             Ok(_) => {}
             Err(error) => panic!("unexpected error: {:?}", error),
         }
+        let create_ask_msg_2 = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "aaaaaaaa-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response_2 = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg_2.clone(),
+        );
+        match create_ask_response_2 {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
 
         // modify ask_required_attributes with active ask
         let exec_info = mock_info("exec_1", &[]);

--- a/src/tests/execute/expire_bid_tests.rs
+++ b/src/tests/execute/expire_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod expire_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -83,8 +83,9 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -155,8 +156,9 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -263,9 +265,11 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 

--- a/src/tests/execute/reject_bid_tests.rs
+++ b/src/tests/execute/reject_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod reject_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -83,8 +83,9 @@ mod reject_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -156,8 +157,9 @@ mod reject_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -229,8 +231,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -358,8 +362,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -490,8 +496,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -622,8 +630,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -720,8 +730,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order not updated
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -815,8 +827,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order not updated
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/query/get_bid_tests.rs
+++ b/src/tests/query/get_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod get_bid_tests {
-    use crate::bid_order::{get_bid_storage, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::contract::query;
     use crate::msg::QueryMsg;
     use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
@@ -34,8 +34,7 @@ mod get_bid_tests {
             },
         };
 
-        let mut bid_storage = get_bid_storage(&mut deps.storage);
-        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
+        if let Err(error) = BIDS_V3.save(&mut deps.storage, bid_order.id.as_bytes(), &bid_order) {
             panic!("unexpected error: {:?}", error);
         };
 
@@ -76,8 +75,7 @@ mod get_bid_tests {
             },
         };
 
-        let mut bid_storage = get_bid_storage(&mut deps.storage);
-        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
+        if let Err(error) = BIDS_V3.save(&mut deps.storage, bid_order.id.as_bytes(), &bid_order) {
             panic!("unexpected error: {:?}", error);
         };
 

--- a/src/tests/test_setup_utils.rs
+++ b/src/tests/test_setup_utils.rs
@@ -1,5 +1,5 @@
 use crate::ask_order::{get_ask_storage, AskOrderV1};
-use crate::bid_order::{get_bid_storage, BidOrderV3};
+use crate::bid_order::{BidOrderV3, BIDS_V3};
 use crate::contract_info::{set_contract_info, ContractInfoV3};
 use crate::tests::test_constants::{APPROVER_1, APPROVER_2, BASE_DENOM};
 use cosmwasm_std::{Addr, Storage, Uint128};
@@ -40,8 +40,7 @@ pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
 }
 
 pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV3) {
-    let mut bid_storage = get_bid_storage(storage);
-    if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
+    if let Err(error) = BIDS_V3.save(storage, bid_order.id.as_bytes(), bid_order) {
         panic!("unexpected error: {:?}", error);
     };
 }


### PR DESCRIPTION
Migrate the bid order storage from `cosmwasm-storage::Bucket` to `cw-storage-plus:Map`
- Update the src, and tests

Migrate from `v0.19.2` to this version locally to verify the storage is not broken as a result of this migration
- Tested reading the orders and there was no issue