### PR TITLE
Migrate ask order from Bucket to Map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+
+[[package]]
 name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,9 +190,9 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
+checksum = "871ce1d5a4b00ed1741f84b377eec19fadd81a904a227bc1e268d76539d26f5e"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -197,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
+checksum = "7ce8b44b45a7c8c6d6f770cd0a51458c2445c7c15b6115e1d215fa35c77b305c"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -230,11 +236,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
+checksum = "da78abcf059181e8cb01e95e5003cf64fe95dde6c72b3fe37e5cabc75cdba32a"
 dependencies = [
  "base64",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -245,14 +252,13 @@ dependencies = [
  "serde-json-wasm",
  "sha2 0.10.6",
  "thiserror",
- "uint",
 ]
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.2.3"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639bc36408bc1ac45e3323166ceeb8f0b91b55a941c4ad59d389829002fbbd94"
+checksum = "b52be0d56b78f502f3acb75e40908a0d04d9f265b6beb0f86b36ec2ece048748"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -266,12 +272,6 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a5083c258acd68386734f428a5a171b29f7d733151ae83090c6fcc9417ffa"
+checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -882,12 +882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,18 +943,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ overflow-checks = true
 #backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "1.2.3" }
-cosmwasm-storage = { version = "1.2.3", features = ["iterator"] }
-cw-storage-plus = { version = "1.0.1" }
+cosmwasm-std = { version = "1.3.3" }
+cw-storage-plus = { version = "1.1.0" }
+cosmwasm-storage = { version = "1.3.3", features = ["iterator"] }
 provwasm-std = { version = "1.1.2" }
 rust_decimal = "1.29.0"
 schemars = "0.8.11"

--- a/src/ask_order.rs
+++ b/src/ask_order.rs
@@ -9,10 +9,9 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-pub static NAMESPACE_ORDER_ASK: &[u8] = b"ask";
-pub const NAMESPACE_ORDER_ASK_V2: &str = "ask";
+pub const NAMESPACE_ORDER_ASK: &str = "ask";
 
-pub const ASKS_V1: Map<&[u8], AskOrderV1> = Map::new(NAMESPACE_ORDER_ASK_V2);
+pub const ASKS_V1: Map<&[u8], AskOrderV1> = Map::new(NAMESPACE_ORDER_ASK);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum AskOrderStatus {

--- a/src/ask_order.rs
+++ b/src/ask_order.rs
@@ -2,14 +2,17 @@ use crate::contract_info::require_version;
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
 use crate::version_info::get_version_info;
-use cosmwasm_std::{Addr, Coin, DepsMut, Storage, Uint128};
-use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
+use cosmwasm_std::{Addr, Coin, DepsMut, Uint128};
+use cw_storage_plus::Map;
 use provwasm_std::ProvenanceQuery;
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
 pub static NAMESPACE_ORDER_ASK: &[u8] = b"ask";
+pub const NAMESPACE_ORDER_ASK_V2: &str = "ask";
+
+pub const ASKS_V1: Map<&[u8], AskOrderV1> = Map::new(NAMESPACE_ORDER_ASK_V2);
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum AskOrderStatus {
@@ -35,14 +38,6 @@ pub struct AskOrderV1 {
     pub quote: String,
     pub price: String,
     pub size: Uint128,
-}
-
-pub fn get_ask_storage(storage: &mut dyn Storage) -> Bucket<AskOrderV1> {
-    bucket(storage, NAMESPACE_ORDER_ASK)
-}
-
-pub fn get_ask_storage_read(storage: &dyn Storage) -> ReadonlyBucket<AskOrderV1> {
-    bucket_read(storage, NAMESPACE_ORDER_ASK)
 }
 
 pub fn migrate_ask_orders(

--- a/src/bid_order.rs
+++ b/src/bid_order.rs
@@ -240,7 +240,6 @@ pub fn migrate_bid_orders(
         // Load the BidOrderV2 items, convert to BidOrderV3, save as BidOrderV3
         for existing_bid_order_v2_id in existing_bid_order_v2_ids {
             let bid_order_v2: BidOrderV2 = BIDS_V2.load(store, &existing_bid_order_v2_id)?;
-            // bucket_read(store, NAMESPACE_ORDER_BID).load(&existing_bid_order_v2_id)?;
             let bid_order_v3: BidOrderV3 = bid_order_v2.into();
 
             BIDS_V3.save(store, &existing_bid_order_v2_id, &bid_order_v3)?

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1062,9 +1062,7 @@ fn modify_contract(
         }
     }
 
-    // Option 1 (Requires migrating Bucket -> Map)
     let contains_bid = !BIDS_V3.is_empty(deps.storage);
-
     if contains_bid {
         match &bid_required_attributes {
             None => {}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4,10 +4,7 @@ use cosmwasm_std::{
 };
 use provwasm_std::{transfer_marker_coins, ProvenanceMsg, ProvenanceQuerier, ProvenanceQuery};
 
-use crate::ask_order::{
-    get_ask_storage, get_ask_storage_read, migrate_ask_orders, AskOrderClass, AskOrderStatus,
-    AskOrderV1,
-};
+use crate::ask_order::{migrate_ask_orders, AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
 use crate::bid_order::{migrate_bid_orders, BidOrderV3, BIDS_V3};
 use crate::common::{Action, ContractAction, FeeInfo};
 use crate::contract_info::{
@@ -271,10 +268,9 @@ fn approve_ask(
         }
     }
 
-    let mut ask_storage = get_ask_storage(deps.storage);
-
     // update ask order
-    let updated_ask_order = ask_storage.update(
+    let updated_ask_order = ASKS_V1.update(
+        deps.storage,
         id.as_bytes(),
         |stored_ask_order| -> Result<AskOrderV1, ContractError> {
             match stored_ask_order {
@@ -429,21 +425,22 @@ fn create_ask(
         }
     }
 
-    let mut ask_storage = get_ask_storage(deps.storage);
-
     if ask_order.base.ne(&contract_info.base_denom) {
         ask_order.class = AskOrderClass::Convertible {
             status: AskOrderStatus::PendingIssuerApproval,
         };
     };
 
-    if ask_storage.may_load(ask_order.id.as_bytes())?.is_some() {
+    if ASKS_V1
+        .may_load(deps.storage, ask_order.id.as_bytes())?
+        .is_some()
+    {
         return Err(ContractError::InvalidFields {
             fields: vec![String::from("id")],
         });
     }
 
-    ask_storage.save(ask_order.id.as_bytes(), &ask_order)?;
+    ASKS_V1.save(deps.storage, ask_order.id.as_bytes(), &ask_order)?;
 
     let mut response = Response::new().add_attributes(vec![
         attr("action", ContractAction::CreateAsk.to_string()),
@@ -667,7 +664,6 @@ fn cancel_ask(
         return Err(ContractError::CancelWithFunds);
     }
 
-    let ask_storage = get_ask_storage_read(deps.storage);
     let AskOrderV1 {
         id,
         owner,
@@ -675,16 +671,15 @@ fn cancel_ask(
         base,
         size,
         ..
-    } = ask_storage
-        .load(id.as_bytes())
+    } = ASKS_V1
+        .load(deps.storage, id.as_bytes())
         .map_err(|error| ContractError::LoadOrderFailed { error })?;
     if !info.sender.eq(&owner) {
         return Err(ContractError::Unauthorized);
     }
 
     // remove the ask order from storage
-    let mut ask_storage = get_ask_storage(deps.storage);
-    ask_storage.remove(id.as_bytes());
+    ASKS_V1.remove(deps.storage, id.as_bytes());
 
     // is ask base a marker
     let is_base_restricted_marker = is_restricted_marker(&deps.querier, base.clone());
@@ -760,11 +755,9 @@ fn reverse_ask(
         return Err(ContractError::Unauthorized);
     }
 
-    let ask_storage = get_ask_storage_read(deps.storage);
-
     // retrieve the order
-    let mut ask_order = ask_storage
-        .load(id.as_bytes())
+    let mut ask_order = ASKS_V1
+        .load(deps.storage, id.as_bytes())
         .map_err(|error| ContractError::LoadOrderFailed { error })?;
 
     // determine the effective cancel size
@@ -838,14 +831,12 @@ fn reverse_ask(
         });
     }
 
-    let mut ask_storage = get_ask_storage(deps.storage);
-
     // remove the ask order from storage if remaining size is 0, otherwise, store updated order
     if ask_order.size.is_zero() {
-        ask_storage.remove(ask_order.id.as_bytes());
+        ASKS_V1.remove(deps.storage, ask_order.id.as_bytes());
         response = response.add_attributes(vec![attr("order_open", "false")]);
     } else {
-        ask_storage.save(ask_order.id.as_bytes(), &ask_order)?;
+        ASKS_V1.save(deps.storage, ask_order.id.as_bytes(), &ask_order)?;
         response = response.add_attributes(vec![attr("order_open", "true")]);
     }
 
@@ -1043,9 +1034,8 @@ fn modify_contract(
         return Err(ContractError::Unauthorized);
     }
 
-    let ask_storage = get_ask_storage_read(deps.storage);
-    let ask_orders: Vec<AskOrderV1> = ask_storage
-        .range(None, None, Order::Ascending)
+    let ask_orders: Vec<AskOrderV1> = ASKS_V1
+        .range(deps.storage, None, None, Order::Ascending)
         .map(|kv_ask: StdResult<Record<AskOrderV1>>| {
             let (_, ask_order) = kv_ask.unwrap();
             ask_order
@@ -1141,9 +1131,8 @@ fn execute_match(
         return Err(ContractError::ExecuteWithFunds);
     }
 
-    let ask_storage_read = get_ask_storage_read(deps.storage);
-    let mut ask_order = ask_storage_read
-        .load(ask_id.as_bytes())
+    let mut ask_order = ASKS_V1
+        .load(deps.storage, ask_id.as_bytes())
         .map_err(|error| ContractError::LoadOrderFailed { error })?;
 
     let mut bid_order = BIDS_V3
@@ -1575,10 +1564,11 @@ fn execute_match(
 
     // finally update or remove the orders from storage
     if ask_order.size.is_zero() {
-        get_ask_storage(deps.storage).remove(ask_id.as_bytes());
+        ASKS_V1.remove(deps.storage, ask_id.as_bytes());
     } else {
-        get_ask_storage(deps.storage)
-            .update(ask_id.as_bytes(), |_| -> StdResult<_> { Ok(ask_order) })?;
+        ASKS_V1.update(deps.storage, ask_id.as_bytes(), |_| -> StdResult<_> {
+            Ok(ask_order)
+        })?;
     }
 
     if bid_order.get_remaining_base().eq(&Uint128::zero()) {
@@ -1626,8 +1616,7 @@ pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult
 
     match msg {
         QueryMsg::GetAsk { id } => {
-            let ask_storage_read = get_ask_storage_read(deps.storage);
-            return to_binary(&ask_storage_read.load(id.as_bytes())?);
+            return to_binary(&ASKS_V1.load(deps.storage, id.as_bytes())?);
         }
         QueryMsg::GetBid { id } => {
             return to_binary(&BIDS_V3.load(deps.storage, id.as_bytes())?);

--- a/src/tests/execute/approve_ask_tests.rs
+++ b/src/tests/execute/approve_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod approve_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
     use crate::error::ContractError;
@@ -122,8 +122,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order update
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -214,8 +216,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order the same
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(stored_order, existing_ask_order)
             }
@@ -354,8 +358,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order update
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -444,8 +450,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -529,8 +537,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -614,8 +624,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -699,8 +711,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -911,8 +925,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order update
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -996,8 +1012,10 @@ mod approve_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/execute/cancel_ask_tests.rs
+++ b/src/tests/execute/cancel_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod cancel_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
     use crate::bid_order::BidOrderV3;
     use crate::contract::execute;
     use crate::error::ContractError;
@@ -72,8 +72,9 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, HYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -159,8 +160,9 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(UNHYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, UNHYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -252,9 +254,11 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 
@@ -326,9 +330,11 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 
@@ -473,9 +479,11 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 
@@ -685,7 +693,6 @@ mod cancel_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(ask_id.as_bytes()).is_err());
+        assert!(ASKS_V1.load(&deps.storage, ask_id.as_bytes()).is_err());
     }
 }

--- a/src/tests/execute/cancel_bid_tests.rs
+++ b/src/tests/execute/cancel_bid_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod cancel_bid_tests {
     use crate::ask_order::{AskOrderClass, AskOrderV1};
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -89,8 +89,9 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -166,8 +167,9 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -292,9 +294,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -401,9 +405,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -503,9 +509,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -647,9 +655,11 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -893,7 +903,6 @@ mod cancel_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(bid_id.as_bytes()).is_err());
+        assert!(BIDS_V3.load(&deps.storage, bid_id.as_bytes()).is_err());
     }
 }

--- a/src/tests/execute/create_ask_tests.rs
+++ b/src/tests/execute/create_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod create_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
     use crate::error::ContractError;
@@ -118,7 +118,6 @@ mod create_ask_tests {
         }
 
         // verify ask order stored
-        let ask_storage = get_ask_storage_read(&deps.storage);
         if let ExecuteMsg::CreateAsk {
             id,
             base,
@@ -127,7 +126,10 @@ mod create_ask_tests {
             size,
         } = create_ask_msg
         {
-            match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match ASKS_V1.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -231,7 +233,6 @@ mod create_ask_tests {
         }
 
         // verify ask order stored
-        let ask_storage = get_ask_storage_read(&deps.storage);
         if let ExecuteMsg::CreateAsk {
             id,
             base,
@@ -240,7 +241,10 @@ mod create_ask_tests {
             size,
         } = create_ask_msg
         {
-            match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match ASKS_V1.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -380,7 +384,6 @@ mod create_ask_tests {
         }
 
         // verify ask order stored
-        let ask_storage = get_ask_storage_read(&deps.storage);
         if let ExecuteMsg::CreateAsk {
             id,
             base,
@@ -389,7 +392,10 @@ mod create_ask_tests {
             size,
         } = create_ask_msg
         {
-            match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match ASKS_V1.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -562,9 +568,10 @@ mod create_ask_tests {
         }
 
         // verify ask order stored is the original order
-        let ask_storage = get_ask_storage_read(&deps.storage);
-
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/execute/create_bid_tests.rs
+++ b/src/tests/execute/create_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod create_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -137,7 +137,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -148,7 +147,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -283,7 +285,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -294,7 +295,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -407,7 +411,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let ask_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -418,7 +421,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -541,7 +547,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -552,7 +557,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -675,7 +683,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             id,
             base,
@@ -686,7 +693,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -809,7 +819,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -820,7 +829,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -980,7 +992,6 @@ mod create_bid_tests {
         }
 
         // verify bid order stored
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
         if let ExecuteMsg::CreateBid {
             base,
             fee,
@@ -991,7 +1002,10 @@ mod create_bid_tests {
             size,
         } = create_bid_msg
         {
-            match bid_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+            match BIDS_V3.load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+            ) {
                 Ok(stored_order) => {
                     assert_eq!(
                         stored_order,
@@ -1186,9 +1200,10 @@ mod create_bid_tests {
         }
 
         // verify bid order stored is the original order
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/execute/execute_match_tests.rs
+++ b/src/tests/execute/execute_match_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod execute_match_tests {
     use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -136,9 +136,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 
@@ -281,9 +283,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -407,9 +411,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -533,9 +539,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -662,9 +670,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -781,9 +791,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -921,9 +933,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1063,9 +1077,11 @@ mod execute_match_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1183,8 +1199,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1355,8 +1373,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1539,8 +1559,10 @@ mod execute_match_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1703,9 +1725,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -1841,8 +1865,10 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -2025,8 +2051,10 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -2230,9 +2258,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2357,9 +2387,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2496,9 +2528,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2659,9 +2693,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -2822,9 +2858,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3019,9 +3057,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3230,9 +3270,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3406,9 +3448,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -3652,9 +3696,11 @@ mod execute_match_tests {
             .is_err());
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -4184,9 +4230,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order still exists
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 
@@ -4279,9 +4327,11 @@ mod execute_match_tests {
             .is_ok());
 
         // verify bid order still exists
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_ok());
     }
 }

--- a/src/tests/execute/execute_match_tests.rs
+++ b/src/tests/execute/execute_match_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod execute_match_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
     use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
@@ -130,9 +130,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order removed from storage
@@ -277,9 +279,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -405,9 +409,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -533,9 +539,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -664,9 +672,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -785,9 +795,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -927,9 +939,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -1055,8 +1069,10 @@ mod execute_match_tests {
         }
 
         // verify ask order updated
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1231,9 +1247,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 
@@ -1351,8 +1369,10 @@ mod execute_match_tests {
         }
 
         // verify ask order updated
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1531,8 +1551,10 @@ mod execute_match_tests {
         }
 
         // verify ask order updated
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -1719,9 +1741,11 @@ mod execute_match_tests {
         }
 
         // verify ask order IS NOT removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order removed from storage
@@ -1859,9 +1883,11 @@ mod execute_match_tests {
         }
 
         // verify ask order IS NOT removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order update
@@ -2045,9 +2071,11 @@ mod execute_match_tests {
         }
 
         // verify ask order IS NOT removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order removed from storage
@@ -2252,9 +2280,11 @@ mod execute_match_tests {
         }
 
         // verify ask order IS NOT removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order removed from storage
@@ -2381,9 +2411,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -2522,9 +2554,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -2687,9 +2721,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -2852,9 +2888,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -3051,9 +3089,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -3264,9 +3304,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -3442,9 +3484,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -3690,9 +3734,11 @@ mod execute_match_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
 
         // verify bid order removed from storage
@@ -4224,9 +4270,11 @@ mod execute_match_tests {
         }
 
         // verify ask order still exists
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order still exists
@@ -4321,9 +4369,11 @@ mod execute_match_tests {
         }
 
         // verify ask order still exists
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_ok());
 
         // verify bid order still exists

--- a/src/tests/execute/execute_modify_tests.rs
+++ b/src/tests/execute/execute_modify_tests.rs
@@ -641,6 +641,23 @@ mod execute_modify_test {
             Ok(_) => {}
             Err(error) => panic!("unexpected error: {:?}", error),
         }
+        let create_ask_msg_2 = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "aaaaaaaa-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response_2 = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg_2.clone(),
+        );
+        match create_ask_response_2 {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
 
         // modify ask_required_attributes with active ask
         let exec_info = mock_info("exec_1", &[]);

--- a/src/tests/execute/expire_ask_tests.rs
+++ b/src/tests/execute/expire_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod expire_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderStatus, AskOrderV1, ASKS_V1};
     use crate::contract::execute;
     use crate::error::ContractError;
     use crate::msg::ExecuteMsg;
@@ -70,8 +70,9 @@ mod expire_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, HYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -133,8 +134,9 @@ mod expire_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(UNHYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, UNHYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -233,9 +235,11 @@ mod expire_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 
@@ -310,9 +314,11 @@ mod expire_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 
@@ -459,9 +465,11 @@ mod expire_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage
-            .load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes())
+        assert!(ASKS_V1
+            .load(
+                &deps.storage,
+                "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()
+            )
             .is_err());
     }
 

--- a/src/tests/execute/expire_bid_tests.rs
+++ b/src/tests/execute/expire_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod expire_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -83,8 +83,9 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -155,8 +156,9 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -263,9 +265,11 @@ mod expire_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage
-            .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
+        assert!(BIDS_V3
+            .load(
+                &deps.storage,
+                "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()
+            )
             .is_err());
     }
 

--- a/src/tests/execute/reject_ask_tests.rs
+++ b/src/tests/execute/reject_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod reject_ask_tests {
-    use crate::ask_order::{get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderV1, ASKS_V1};
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
     use crate::error::ContractError;
@@ -73,8 +73,9 @@ mod reject_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, HYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -137,8 +138,9 @@ mod reject_ask_tests {
         }
 
         // verify ask order removed from storage
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(UNHYPHENATED_ASK_ID.as_bytes()).is_err());
+        assert!(ASKS_V1
+            .load(&deps.storage, UNHYPHENATED_ASK_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -201,8 +203,10 @@ mod reject_ask_tests {
         }
 
         // verify ask order updated
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -262,8 +266,10 @@ mod reject_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -340,8 +346,10 @@ mod reject_ask_tests {
         }
 
         // verify ask order unchanged
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        match ask_storage.load("ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes()) {
+        match ASKS_V1.load(
+            &deps.storage,
+            "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/execute/reject_bid_tests.rs
+++ b/src/tests/execute/reject_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod reject_bid_tests {
-    use crate::bid_order::{get_bid_storage_read, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::common::FeeInfo;
     use crate::contract::execute;
     use crate::contract_info::ContractInfoV3;
@@ -83,8 +83,9 @@ mod reject_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(HYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, HYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -156,8 +157,9 @@ mod reject_bid_tests {
         }
 
         // verify bid order removed from storage
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        assert!(bid_storage.load(UNHYPHENATED_BID_ID.as_bytes()).is_err());
+        assert!(BIDS_V3
+            .load(&deps.storage, UNHYPHENATED_BID_ID.as_bytes())
+            .is_err());
     }
 
     #[test]
@@ -229,8 +231,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -358,8 +362,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -490,8 +496,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -622,8 +630,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order update
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -720,8 +730,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order not updated
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,
@@ -815,8 +827,10 @@ mod reject_bid_tests {
         }
 
         // verify bid order not updated
-        let bid_storage = get_bid_storage_read::<BidOrderV3>(&deps.storage);
-        match bid_storage.load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes()) {
+        match BIDS_V3.load(
+            &deps.storage,
+            "c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes(),
+        ) {
             Ok(stored_order) => {
                 assert_eq!(
                     stored_order,

--- a/src/tests/query/get_ask_tests.rs
+++ b/src/tests/query/get_ask_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod get_ask_tests {
-    use crate::ask_order::{get_ask_storage, get_ask_storage_read, AskOrderClass, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderV1, ASKS_V1};
     use crate::contract::query;
     use crate::msg::QueryMsg;
     use crate::tests::test_constants::{HYPHENATED_ASK_ID, UNHYPHENATED_ASK_ID};
@@ -26,14 +26,16 @@ mod get_ask_tests {
             size: Uint128::new(200),
         };
 
-        let mut ask_storage = get_ask_storage(&mut deps.storage);
-        if let Err(error) = ask_storage.save(HYPHENATED_ASK_ID.as_bytes(), &ask_order) {
+        if let Err(error) =
+            ASKS_V1.save(&mut deps.storage, HYPHENATED_ASK_ID.as_bytes(), &ask_order)
+        {
             panic!("unexpected error: {:?}", error)
         };
 
         // verify ask order still exists
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(HYPHENATED_ASK_ID.as_bytes()).is_ok());
+        assert!(ASKS_V1
+            .load(&deps.storage, HYPHENATED_ASK_ID.as_bytes())
+            .is_ok());
 
         // query for ask order
         let query_ask_response = query(
@@ -63,14 +65,18 @@ mod get_ask_tests {
             quote: "quote_1".into(),
             size: Uint128::new(200),
         };
-        let mut ask_storage = get_ask_storage(&mut deps.storage);
-        if let Err(error) = ask_storage.save(UNHYPHENATED_ASK_ID.as_bytes(), &ask_order) {
+        if let Err(error) = ASKS_V1.save(
+            &mut deps.storage,
+            UNHYPHENATED_ASK_ID.as_bytes(),
+            &ask_order,
+        ) {
             panic!("unexpected error: {:?}", error)
         };
 
         // verify ask order still exists
-        let ask_storage = get_ask_storage_read(&deps.storage);
-        assert!(ask_storage.load(UNHYPHENATED_ASK_ID.as_bytes()).is_ok());
+        assert!(ASKS_V1
+            .load(&deps.storage, UNHYPHENATED_ASK_ID.as_bytes())
+            .is_ok());
 
         // query for ask order
         let query_ask_response = query(

--- a/src/tests/query/get_bid_tests.rs
+++ b/src/tests/query/get_bid_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod get_bid_tests {
-    use crate::bid_order::{get_bid_storage, BidOrderV3};
+    use crate::bid_order::{BidOrderV3, BIDS_V3};
     use crate::contract::query;
     use crate::msg::QueryMsg;
     use crate::tests::test_constants::{HYPHENATED_BID_ID, UNHYPHENATED_BID_ID};
@@ -34,8 +34,7 @@ mod get_bid_tests {
             },
         };
 
-        let mut bid_storage = get_bid_storage(&mut deps.storage);
-        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
+        if let Err(error) = BIDS_V3.save(&mut deps.storage, bid_order.id.as_bytes(), &bid_order) {
             panic!("unexpected error: {:?}", error);
         };
 
@@ -76,8 +75,7 @@ mod get_bid_tests {
             },
         };
 
-        let mut bid_storage = get_bid_storage(&mut deps.storage);
-        if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), &bid_order) {
+        if let Err(error) = BIDS_V3.save(&mut deps.storage, bid_order.id.as_bytes(), &bid_order) {
             panic!("unexpected error: {:?}", error);
         };
 

--- a/src/tests/test_setup_utils.rs
+++ b/src/tests/test_setup_utils.rs
@@ -1,5 +1,5 @@
 use crate::ask_order::{get_ask_storage, AskOrderV1};
-use crate::bid_order::{get_bid_storage, BidOrderV3};
+use crate::bid_order::{BidOrderV3, BIDS_V3};
 use crate::contract_info::{set_contract_info, ContractInfoV3};
 use crate::tests::test_constants::{APPROVER_1, APPROVER_2, BASE_DENOM};
 use cosmwasm_std::{Addr, Storage, Uint128};
@@ -40,8 +40,7 @@ pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
 }
 
 pub fn store_test_bid(storage: &mut dyn Storage, bid_order: &BidOrderV3) {
-    let mut bid_storage = get_bid_storage(storage);
-    if let Err(error) = bid_storage.save(bid_order.id.as_bytes(), bid_order) {
+    if let Err(error) = BIDS_V3.save(storage, bid_order.id.as_bytes(), bid_order) {
         panic!("unexpected error: {:?}", error);
     };
 }

--- a/src/tests/test_setup_utils.rs
+++ b/src/tests/test_setup_utils.rs
@@ -1,4 +1,4 @@
-use crate::ask_order::{get_ask_storage, AskOrderV1};
+use crate::ask_order::{AskOrderV1, ASKS_V1};
 use crate::bid_order::{BidOrderV3, BIDS_V3};
 use crate::contract_info::{set_contract_info, ContractInfoV3};
 use crate::tests::test_constants::{APPROVER_1, APPROVER_2, BASE_DENOM};
@@ -33,8 +33,7 @@ pub fn setup_test_base_contract_v3(storage: &mut dyn Storage) {
 }
 
 pub fn store_test_ask(storage: &mut dyn Storage, ask_order: &AskOrderV1) {
-    let mut ask_storage = get_ask_storage(storage);
-    if let Err(error) = ask_storage.save(ask_order.id.as_bytes(), ask_order) {
+    if let Err(error) = ASKS_V1.save(storage, ask_order.id.as_bytes(), ask_order) {
         panic!("unexpected error: {:?}", error)
     };
 }


### PR DESCRIPTION
Migrate the ask order storage from `cosmwasm-storage::Bucket` to `cw-storage-plus:Map`
- Update the src, and tests

Migrate from `v0.19.2` to this version locally to verify the storage is not broken as a result of this migration
- Tested reading the orders and there was no issue